### PR TITLE
Fix moving average zero-length bug

### DIFF
--- a/indicators/technical_indicators.py
+++ b/indicators/technical_indicators.py
@@ -3,6 +3,9 @@
 import pandas as pd
 
 def moving_average(prices: list[float], period: int) -> float:
+    """Simple moving average with basic safety checks."""
+    if not prices:
+        return 0.0
     if len(prices) < period:
         return sum(prices) / len(prices)
     return sum(prices[-period:]) / period


### PR DESCRIPTION
## Summary
- handle empty list case in `moving_average`

## Testing
- `python -m py_compile indicators/technical_indicators.py`
- `python -m pip install -r requirements.txt`
- `python - <<'PY'
from indicators.technical_indicators import moving_average
print('ma empty:', moving_average([], 10))
print('ma short:', moving_average([1,2,3], 5))
print('ma long:', moving_average([1,2,3,4,5,6], 3))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6845d9be1224833083253e36859a1261