### PR TITLE
Add dynamic signal generation and risk management

### DIFF
--- a/data/sentiment.py
+++ b/data/sentiment.py
@@ -82,3 +82,26 @@ async def fetch_newsapi_sentiment(api_key: str, query: str = "Bitcoin") -> dict:
         "count": len(scores),
         "timestamp": datetime.utcnow().isoformat()
     }
+
+# === Reddit ===
+
+async def fetch_reddit_sentiment(subreddit: str, limit: int = 50) -> dict:
+    """Gather sentiment score from a subreddit."""
+    url = f"https://www.reddit.com/r/{subreddit}/hot.json?limit={limit}"
+    headers = {"User-Agent": "LysaraBot/0.1"}
+    scores = []
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                data = await response.json()
+                posts = data.get("data", {}).get("children", [])
+                for post in posts:
+                    text = post.get("data", {}).get("title", "") + " " + post.get("data", {}).get("selftext", "")
+                    scores.append(analyze_sentiment(text))
+    except Exception as e:
+        logging.error(f"Reddit sentiment error: {e}")
+    return {
+        "score": round(sum(scores) / len(scores), 3) if scores else 0.0,
+        "count": len(scores),
+        "timestamp": datetime.utcnow().isoformat(),
+    }

--- a/main.py
+++ b/main.py
@@ -20,6 +20,9 @@ async def main():
     )
 
     logging.info("Lysara Investments booting up...")
+    logging.info(
+        f"Simulation mode: {config.get('simulation_mode', True)} | Risk per trade: {config.get('crypto_settings', {}).get('risk_per_trade')}"
+    )
 
     launcher = BotLauncher(config)
     launcher.start_all_bots()

--- a/risk/risk.py
+++ b/risk/risk.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+import numpy as np
+
+from .risk_manager import RiskManager
+
+@dataclass
+class StopLevels:
+    stop: float
+    target: float
+    rr: float
+
+class DynamicRisk:
+    """Extension around RiskManager for dynamic sizing and stops."""
+
+    def __init__(self, manager: RiskManager, atr_period: int = 14, vol_mult: float = 3.0):
+        self.manager = manager
+        self.atr_period = atr_period
+        self.vol_mult = vol_mult
+
+    def _volatility(self, prices: list[float]) -> float:
+        if len(prices) < 2:
+            return 0.0
+        arr = np.diff(prices[-self.atr_period:])
+        return float(np.std(arr))
+
+    def position_size(self, price: float, confidence: float, prices: list[float]) -> float:
+        base = self.manager.get_position_size(price)
+        vol = self._volatility(prices) or 1.0
+        size = base * max(confidence, 0.1) / vol
+        return round(size, 6)
+
+    def stop_levels(self, entry_price: float, side: str, prices: list[float], min_rr: float = 1.5) -> StopLevels:
+        vol = self._volatility(prices)
+        trail = vol * self.vol_mult
+        if side == "buy":
+            stop = max(entry_price - trail, 0)
+            target = entry_price + trail * min_rr
+        else:
+            stop = entry_price + trail
+            target = max(entry_price - trail * min_rr, 0)
+        rr = abs(target - entry_price) / max(abs(entry_price - stop), 1e-6)
+        return StopLevels(stop=stop, target=target, rr=rr)

--- a/services/background_tasks.py
+++ b/services/background_tasks.py
@@ -2,7 +2,11 @@
 
 import asyncio
 import logging
-from data.sentiment import fetch_cryptopanic_sentiment, fetch_newsapi_sentiment
+from data.sentiment import (
+    fetch_cryptopanic_sentiment,
+    fetch_newsapi_sentiment,
+    fetch_reddit_sentiment,
+)
 
 class BackgroundTasks:
     def __init__(self, config: dict):
@@ -10,6 +14,8 @@ class BackgroundTasks:
         self.crypto_symbols = config.get("TRADE_SYMBOLS", ["BTC-USD", "ETH-USD"])
         self.cp_key = config["api_keys"].get("cryptopanic")
         self.newsapi_key = config["api_keys"].get("newsapi")
+        self.subreddits = config.get("reddit_subreddits", ["Cryptocurrency"])
+        self.sentiment_scores: dict = {}
         self._running = True
 
     async def run_sentiment_loop(self, interval: int = 60):
@@ -21,11 +27,20 @@ class BackgroundTasks:
 
             if self.cp_key:
                 scores = await fetch_cryptopanic_sentiment(self.cp_key, self.crypto_symbols)
+                self.sentiment_scores["cryptopanic"] = scores
                 logging.info(f"CryptoPanic Sentiment: {scores}")
 
             if self.newsapi_key:
                 news = await fetch_newsapi_sentiment(self.newsapi_key)
+                self.sentiment_scores["newsapi"] = news
                 logging.info(f"NewsAPI Sentiment: {news}")
+
+            if self.subreddits:
+                reddit_scores = {}
+                for sub in self.subreddits:
+                    reddit_scores[sub] = await fetch_reddit_sentiment(sub)
+                self.sentiment_scores["reddit"] = reddit_scores
+                logging.info(f"Reddit Sentiment: {reddit_scores}")
 
             await asyncio.sleep(interval)
 

--- a/services/bot_launcher.py
+++ b/services/bot_launcher.py
@@ -54,7 +54,8 @@ class BotLauncher:
             risk=risk,
             config=settings,
             db=self.db,
-            symbol_list=symbols
+            symbol_list=symbols,
+            sentiment_source=self.bg_tasks,
         )
 
         asyncio.create_task(start_crypto_market_feed(symbols))

--- a/signals.py
+++ b/signals.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from indicators.technical_indicators import relative_strength_index
+
+@dataclass
+class Signal:
+    action: str
+    confidence: float
+    details: str
+
+class SignalGenerator:
+    """Combine technical and sentiment data into a trade signal."""
+
+    def __init__(self, tech_weight: float = 0.7, sentiment_weight: float = 0.3):
+        self.tech_weight = tech_weight
+        self.sentiment_weight = sentiment_weight
+
+    def generate(self, prices: list[float], sentiment_score: float) -> Signal:
+        rsi = relative_strength_index(prices)
+        action = "hold"
+        base_conf = 0.0
+        if rsi > 70:
+            action = "sell"
+            base_conf = (rsi - 50) / 50
+        elif rsi < 30:
+            action = "buy"
+            base_conf = (50 - rsi) / 50
+
+        final_conf = base_conf * self.tech_weight + sentiment_score * self.sentiment_weight
+        final_conf = round(max(final_conf, 0.0), 3)
+        details = f"rsi={rsi},sent={sentiment_score}"
+        return Signal(action=action, confidence=final_conf, details=details)

--- a/strategies/crypto/momentum.py
+++ b/strategies/crypto/momentum.py
@@ -2,62 +2,89 @@
 
 import asyncio
 import logging
-from indicators.technical_indicators import relative_strength_index
+from signals import SignalGenerator, Signal
+from risk.risk import DynamicRisk
+from utils.helpers import parse_price
 
 class MomentumStrategy:
-    def __init__(self, api, risk, config, db, symbol_list):
+    def __init__(self, api, risk, config, db, symbol_list, sentiment_source=None):
         self.api = api
         self.risk = risk
         self.config = config
         self.db = db
         self.symbols = symbol_list
+        self.sentiment_source = sentiment_source
         self.price_history = {symbol: [] for symbol in symbol_list}
         self.interval = 10  # seconds
+        self.signal_gen = SignalGenerator()
+        self.dynamic_risk = DynamicRisk(risk,
+                                       config.get("atr_period", 14),
+                                       config.get("volatility_multiplier", 3))
 
     async def run(self):
         while True:
             for symbol in self.symbols:
                 try:
                     data = await self.api.fetch_market_price(symbol)
-                    price = float(data.get("price", 0))
+                    price = parse_price(data)
                     self.price_history[symbol].append(price)
 
                     if len(self.price_history[symbol]) > 100:
                         self.price_history[symbol] = self.price_history[symbol][-100:]
 
-                    rsi = relative_strength_index(self.price_history[symbol])
+                    sentiment = await self.get_sentiment(symbol)
+                    signal = self.signal_gen.generate(self.price_history[symbol], sentiment)
 
-                    if rsi > 70:
-                        await self.enter_trade(symbol, price, "sell", rsi)
-                    elif rsi < 30:
-                        await self.enter_trade(symbol, price, "buy", rsi)
+                    if signal.action != "hold" and signal.confidence > 0:
+                        await self.enter_trade(symbol, price, signal)
 
                 except Exception as e:
                     logging.error(f"[Momentum] Error on {symbol}: {e}")
 
             await asyncio.sleep(self.interval)
 
-    async def enter_trade(self, symbol, price, side, rsi):
-        qty = self.risk.get_position_size(price)
+    async def get_sentiment(self, symbol: str) -> float:
+        if not self.sentiment_source:
+            return 0.0
+        scores = self.sentiment_source.sentiment_scores
+        cp = scores.get("cryptopanic", {}).get(symbol, {}).get("score", 0.0)
+        reddit_data = scores.get("reddit", {})
+        reddit_avg = 0.0
+        if reddit_data:
+            for sub in reddit_data.values():
+                reddit_avg += sub.get("score", 0.0)
+            reddit_avg /= max(len(reddit_data), 1)
+        news = scores.get("newsapi", {}).get("score", 0.0)
+        return (cp + reddit_avg + news) / 3
+
+    async def enter_trade(self, symbol: str, price: float, signal: Signal):
+        qty = self.dynamic_risk.position_size(price, signal.confidence, self.price_history[symbol])
         if qty <= 0:
             logging.warning("Momentum: invalid position size.")
             return
 
-        order = await self.api.place_order(
+        stops = self.dynamic_risk.stop_levels(price, signal.action, self.price_history[symbol])
+        if stops.rr < 1.0:
+            logging.info(f"Trade skipped on {symbol} due to RR {stops.rr:.2f}")
+            return
+
+        await self.api.place_order(
             product_id=symbol,
-            side=side,
+            side=signal.action,
             size=qty,
-            order_type="market"
+            order_type="market",
         )
 
         self.db.log_trade(
             symbol=symbol,
-            side=side,
+            side=signal.action,
             quantity=qty,
             price=price,
             profit_loss=None,
-            reason=f"momentum_rsi_{rsi}",
-            market="crypto"
+            reason=signal.details,
+            market="crypto",
         )
 
-        logging.info(f"{side.upper()} {symbol} @ {price} triggered by RSI={rsi}")
+        logging.info(
+            f"{signal.action.upper()} {symbol} @ {price} conf={signal.confidence} RR={stops.rr:.2f} details={signal.details}"
+        )


### PR DESCRIPTION
## Summary
- create `signals.py` for combined technical and sentiment scoring
- implement `risk.py` with dynamic sizing and trailing stop logic
- enhance sentiment module with Reddit support
- store sentiment data in `BackgroundTasks`
- extend `MomentumStrategy` to use new signals and risk modules
- pass sentiment source from `BotLauncher`
- log config details at startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845e054fe888330a7bbf254dda08782