### PR TITLE
Add simulation portfolio tracking

### DIFF
--- a/services/sim_portfolio.py
+++ b/services/sim_portfolio.py
@@ -1,0 +1,66 @@
+import json
+import logging
+from pathlib import Path
+from datetime import datetime
+
+class SimulatedPortfolio:
+    """Simple portfolio tracker for simulation mode."""
+
+    def __init__(self, starting_balance: float = 1000.0, state_file: str = "data/sim_state.json"):
+        self.state_file = Path(state_file)
+        self.starting_balance = starting_balance
+        self.current_balance = starting_balance
+        self.open_positions: dict[str, float] = {}
+        self.trade_history: list[dict] = []
+        self._load_state()
+
+    def _load_state(self):
+        if self.state_file.is_file():
+            try:
+                data = json.loads(self.state_file.read_text())
+                self.starting_balance = data.get("starting_balance", self.starting_balance)
+                self.current_balance = data.get("current_balance", self.starting_balance)
+                self.open_positions = data.get("open_positions", {})
+                self.trade_history = data.get("trade_history", [])
+            except Exception as e:
+                logging.error(f"Failed to load simulation state: {e}")
+        else:
+            logging.info("No existing simulation state found; starting fresh.")
+
+    def _save_state(self):
+        data = {
+            "starting_balance": self.starting_balance,
+            "current_balance": self.current_balance,
+            "open_positions": self.open_positions,
+            "trade_history": self.trade_history,
+        }
+        try:
+            self.state_file.parent.mkdir(parents=True, exist_ok=True)
+            self.state_file.write_text(json.dumps(data, indent=2))
+        except Exception as e:
+            logging.error(f"Failed to save simulation state: {e}")
+
+    def execute_trade(self, asset: str, action: str, size: float, price: float, confidence: float = 0.0):
+        cost = size * price
+        if action.lower() == "buy":
+            self.current_balance -= cost
+            self.open_positions[asset] = self.open_positions.get(asset, 0.0) + size
+        else:
+            self.current_balance += cost
+            self.open_positions[asset] = self.open_positions.get(asset, 0.0) - size
+            if abs(self.open_positions[asset]) < 1e-8:
+                self.open_positions.pop(asset, None)
+
+        trade = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "asset": asset,
+            "action": action,
+            "size": size,
+            "price": price,
+            "confidence": confidence,
+        }
+        self.trade_history.append(trade)
+        self._save_state()
+        logging.info(
+            f"[SIM] Executed {action.upper()} {size} {asset} @ ${price} | New balance: ${self.current_balance:.2f}"
+        )

--- a/strategies/crypto/mean_reversion.py
+++ b/strategies/crypto/mean_reversion.py
@@ -48,7 +48,8 @@ class MeanReversionStrategy:
             side=side,
             size=qty,
             price=price,
-            order_type="market"
+            order_type="market",
+            confidence=0.0,
         )
 
         self.db.log_trade(

--- a/strategies/crypto/momentum.py
+++ b/strategies/crypto/momentum.py
@@ -73,6 +73,8 @@ class MomentumStrategy:
             side=signal.action,
             size=qty,
             order_type="market",
+            price=price,
+            confidence=signal.confidence,
         )
 
         self.db.log_trade(

--- a/strategies/crypto/pairs_trading.py
+++ b/strategies/crypto/pairs_trading.py
@@ -54,12 +54,12 @@ class PairsTradingStrategy:
 
         if direction == "long":
             # Buy 1, Sell 2
-            await self.api.place_order(product_id=self.pair[0], side="buy", size=qty_1)
-            await self.api.place_order(product_id=self.pair[1], side="sell", size=qty_2)
+            await self.api.place_order(product_id=self.pair[0], side="buy", size=qty_1, price=price_1, confidence=0.0)
+            await self.api.place_order(product_id=self.pair[1], side="sell", size=qty_2, price=price_2, confidence=0.0)
         else:
             # Sell 1, Buy 2
-            await self.api.place_order(product_id=self.pair[0], side="sell", size=qty_1)
-            await self.api.place_order(product_id=self.pair[1], side="buy", size=qty_2)
+            await self.api.place_order(product_id=self.pair[0], side="sell", size=qty_1, price=price_1, confidence=0.0)
+            await self.api.place_order(product_id=self.pair[1], side="buy", size=qty_2, price=price_2, confidence=0.0)
 
         self.db.log_trade(
             symbol=f"{self.pair[0]}+{self.pair[1]}",

--- a/strategies/forex/breakout_strategy.py
+++ b/strategies/forex/breakout_strategy.py
@@ -48,7 +48,9 @@ class BreakoutStrategy:
         await self.api.place_order(
             instrument=symbol,
             units=qty if side == "buy" else -qty,
-            order_type="MARKET"
+            order_type="MARKET",
+            price=price,
+            confidence=0.0,
         )
 
         self.db.log_trade(

--- a/strategies/forex/forex_scalping.py
+++ b/strategies/forex/forex_scalping.py
@@ -46,7 +46,9 @@ class ForexScalpingStrategy:
         await self.api.place_order(
             instrument=symbol,
             units=qty if side == "buy" else -qty,
-            order_type="MARKET"
+            order_type="MARKET",
+            price=price,
+            confidence=0.0,
         )
 
         self.db.log_trade(

--- a/strategies/stocks/earnings_play.py
+++ b/strategies/stocks/earnings_play.py
@@ -44,7 +44,9 @@ class EarningsPlayStrategy:
             symbol=symbol,
             side=side,
             quantity=qty,
-            order_type="market"
+            order_type="market",
+            price=price,
+            confidence=0.0,
         )
 
         self.db.log_trade(

--- a/strategies/stocks/stock_momentum.py
+++ b/strategies/stocks/stock_momentum.py
@@ -45,7 +45,9 @@ class StockMomentumStrategy:
             symbol=symbol,
             side=side,
             quantity=qty,
-            order_type="market"
+            order_type="market",
+            price=price,
+            confidence=0.0,
         )
 
         self.db.log_trade(


### PR DESCRIPTION
## Summary
- add `SimulatedPortfolio` helper to persist virtual trades
- integrate portfolio with `BotLauncher` and API clients when `simulation_mode` is enabled
- extend CryptoAPI/StockAPI/ForexAPI to log simulated trades and update balance
- pass price and confidence from strategies during simulated order placement

## Testing
- `python -m py_compile services/sim_portfolio.py api/crypto_api.py api/stock_api.py api/forex_api.py strategies/crypto/momentum.py strategies/crypto/mean_reversion.py strategies/crypto/pairs_trading.py strategies/forex/breakout_strategy.py strategies/forex/forex_scalping.py strategies/stocks/stock_momentum.py strategies/stocks/earnings_play.py services/bot_launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6845f2b249cc8330b91818c8070b91b9