### PR TITLE
Add Alpaca stock trading support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Example environment configuration for Lysara Investments
+
+# Coinbase
+COINBASE_API_KEY=your_coinbase_key
+COINBASE_SECRET_KEY=your_coinbase_secret
+
+# Robinhood (view-only)
+ROBINHOOD_API_KEY=
+ROBINHOOD_USERNAME=
+ROBINHOOD_PASSWORD=
+
+# Reddit, News, Sentiment
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+NEWSAPI_KEY=
+CRYPTOPANIC_KEY=
+SLACK_WEBHOOK_URL=
+
+# System Config
+SIMULATION_MODE=True
+ENABLE_STOCK_TRADING=true
+ALPACA_API_KEY=your_alpaca_key
+ALPACA_SECRET_KEY=your_alpaca_secret
+ALPACA_BASE_URL=https://paper-api.alpaca.markets/v2

--- a/README.txt
+++ b/README.txt
@@ -12,3 +12,9 @@ Lysara Investments is a unified, modular trading engine designed to execute algo
 
 ## 🗂️ Project Structure
 
+### Environment Configuration
+
+Create a `.env` file based on `.env.example` and populate your API keys. At a minimum,
+set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` to enable live or paper stock trading
+through Alpaca.
+

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -22,11 +22,15 @@ class ConfigManager:
         self.base_config['api_keys'] = {
             'coinbase': os.getenv('COINBASE_API_KEY'),
             'coinbase_secret': os.getenv('COINBASE_SECRET_KEY'),
+            'alpaca': os.getenv('ALPACA_API_KEY'),
+            'alpaca_secret': os.getenv('ALPACA_SECRET_KEY'),
+            'alpaca_base_url': os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets/v2'),
             'newsapi': os.getenv('NEWSAPI_KEY'),
             'cryptopanic': os.getenv('CRYPTOPANIC_KEY'),
             'slack_webhook': os.getenv('SLACK_WEBHOOK_URL'),
         }
         self.base_config['simulation_mode'] = os.getenv('SIMULATION_MODE', 'True').lower() in ('true', '1', 'yes')
+        self.base_config['ENABLE_STOCK_TRADING'] = os.getenv('ENABLE_STOCK_TRADING', 'false').lower() in ('true', '1', 'yes')
         self.base_config['log_level'] = os.getenv('LOG_LEVEL', 'INFO')
         self.base_config['db_path'] = os.getenv('DB_PATH', 'trades.db')
         self.base_config['config_path'] = os.getenv('CONFIG_PATH', 'config.json')

--- a/data/market_data_stocks.py
+++ b/data/market_data_stocks.py
@@ -1,44 +1,33 @@
 # data/market_data_stocks.py
 
 import asyncio
-import aiohttp
 import logging
 from datetime import datetime
 
-async def fetch_stock_prices(session, symbols: list[str], api_key: str):
-    """
-    Fetch latest stock prices from a public or Alpaca endpoint.
-    Replace with a real-time feed later if needed.
-    """
-    url = f"https://api.twelvedata.com/price"
-    results = []
+from services.alpaca_manager import AlpacaManager
 
+
+async def fetch_stock_prices(alpaca: AlpacaManager, symbols: list[str]):
+    """Fetch latest stock prices using Alpaca market data."""
+    results = []
     for symbol in symbols:
-        params = {
-            "symbol": symbol,
-            "apikey": api_key
-        }
         try:
-            async with session.get(url, params=params) as response:
-                data = await response.json()
-                results.append({
-                    "symbol": symbol,
-                    "price": float(data.get("price", 0)),
-                    "time": datetime.utcnow().isoformat()
-                })
+            price = (await alpaca.fetch_market_price(symbol)).get("price", 0)
+            results.append({
+                "symbol": symbol,
+                "price": price,
+                "time": datetime.utcnow().isoformat(),
+            })
         except Exception as e:
             logging.error(f"Failed to fetch price for {symbol}: {e}")
-
     return results
 
-async def start_stock_polling_loop(symbols, api_key, interval=10, on_price=None):
-    """
-    Polls stock prices every `interval` seconds using TwelveData or similar.
-    """
-    async with aiohttp.ClientSession() as session:
-        while True:
-            prices = await fetch_stock_prices(session, symbols, api_key)
-            for p in prices:
-                if on_price:
-                    await on_price(p)
-            await asyncio.sleep(interval)
+
+async def start_stock_polling_loop(symbols, alpaca: AlpacaManager, interval=10, on_price=None):
+    """Poll stock prices every `interval` seconds via Alpaca."""
+    while True:
+        prices = await fetch_stock_prices(alpaca, symbols)
+        for p in prices:
+            if on_price:
+                await on_price(p)
+        await asyncio.sleep(interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ streamlit
 textblob
 websockets
 python-dotenv
+alpaca-trade-api

--- a/services/alpaca_manager.py
+++ b/services/alpaca_manager.py
@@ -1,0 +1,82 @@
+import asyncio
+import logging
+from typing import Optional
+
+import alpaca_trade_api as tradeapi
+
+from utils.guardrails import log_live_trade
+
+
+class AlpacaManager:
+    """Wrapper around alpaca-trade-api for async usage."""
+
+    def __init__(
+        self,
+        api_key: str,
+        api_secret: str,
+        base_url: str = "https://paper-api.alpaca.markets",
+        simulation_mode: bool = True,
+        portfolio=None,
+        config: Optional[dict] = None,
+        trade_cooldown: int = 30,
+    ) -> None:
+        self.simulation_mode = simulation_mode
+        self.portfolio = portfolio
+        self.config = config or {}
+        self.trade_cooldown = trade_cooldown
+        self._last_trade: dict[str, float] = {}
+        self.client = tradeapi.REST(api_key, api_secret, base_url, api_version="v2")
+
+    async def get_account(self):
+        if self.simulation_mode:
+            logging.debug("AlpacaManager: returning mock account data")
+            return {"cash": 10000.0, "equity": 10000.0, "buying_power": 10000.0}
+        return await asyncio.to_thread(self.client.get_account)
+
+    async def get_positions(self):
+        if self.simulation_mode:
+            logging.debug("AlpacaManager: returning empty positions in sim mode")
+            return []
+        return await asyncio.to_thread(self.client.list_positions)
+
+    async def fetch_market_price(self, symbol: str) -> dict:
+        trade = await asyncio.to_thread(self.client.get_latest_trade, symbol)
+        return {"price": float(trade.price)}
+
+    async def place_order(
+        self,
+        symbol: str,
+        qty: float,
+        side: str,
+        type: str = "market",
+        time_in_force: str = "day",
+        price: float | None = None,
+    ):
+        if self.simulation_mode:
+            logging.info(f"[SIM] {side.upper()} {qty} {symbol}")
+            if self.portfolio:
+                if price is None:
+                    price = (await self.fetch_market_price(symbol)).get("price", 0)
+                self.portfolio.execute_trade(symbol, side, qty, price)
+            return {"id": "sim", "status": "filled", "symbol": symbol, "qty": qty, "price": price}
+
+        now = asyncio.get_event_loop().time()
+        last = self._last_trade.get(symbol)
+        if last and now - last < self.trade_cooldown:
+            logging.warning(f"Duplicate trade blocked for {symbol}")
+            return {"status": "blocked", "reason": "duplicate"}
+        self._last_trade[symbol] = now
+
+        order = await asyncio.to_thread(
+            self.client.submit_order,
+            symbol=symbol,
+            qty=qty,
+            side=side,
+            type=type,
+            time_in_force=time_in_force,
+            limit_price=price if type == "limit" else None,
+        )
+        trade_price = price if price is not None else (await self.fetch_market_price(symbol)).get("price", 0)
+        await log_live_trade(symbol, side, qty, trade_price, self.config)
+        return order
+


### PR DESCRIPTION
## Summary
- add `.env.example` with Alpaca keys
- update config manager to load Alpaca credentials
- add `AlpacaManager` for trading & data access
- use Alpaca in stock bot launcher and market data polling
- fetch Alpaca holdings in dashboard portfolio
- document new env setup and add dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684655f084b0833081481c7c4294c76c