### PR TITLE
Add OpenAI based AI strategist module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ ENABLE_STOCK_TRADING=true
 ALPACA_API_KEY=your_alpaca_key
 ALPACA_SECRET_KEY=your_alpaca_secret
 ALPACA_BASE_URL=https://paper-api.alpaca.markets/v2
+OPENAI_API_KEY=your_key_here
+ENABLE_AI_STRATEGY=true

--- a/README.txt
+++ b/README.txt
@@ -18,3 +18,5 @@ Create a `.env` file based on `.env.example` and populate your API keys. At a mi
 set `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` to enable live or paper stock trading
 through Alpaca.
 
+To use the optional AI strategist module, set `OPENAI_API_KEY` and enable it with
+`ENABLE_AI_STRATEGY=true`.

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -28,9 +28,11 @@ class ConfigManager:
             'newsapi': os.getenv('NEWSAPI_KEY'),
             'cryptopanic': os.getenv('CRYPTOPANIC_KEY'),
             'slack_webhook': os.getenv('SLACK_WEBHOOK_URL'),
+            'openai': os.getenv('OPENAI_API_KEY'),
         }
         self.base_config['simulation_mode'] = os.getenv('SIMULATION_MODE', 'True').lower() in ('true', '1', 'yes')
         self.base_config['ENABLE_STOCK_TRADING'] = os.getenv('ENABLE_STOCK_TRADING', 'false').lower() in ('true', '1', 'yes')
+        self.base_config['ENABLE_AI_STRATEGY'] = os.getenv('ENABLE_AI_STRATEGY', 'false').lower() in ('true', '1', 'yes')
         self.base_config['log_level'] = os.getenv('LOG_LEVEL', 'INFO')
         self.base_config['db_path'] = os.getenv('DB_PATH', 'trades.db')
         self.base_config['config_path'] = os.getenv('CONFIG_PATH', 'config.json')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ textblob
 websockets
 python-dotenv
 alpaca-trade-api
+openai

--- a/services/ai_strategist.py
+++ b/services/ai_strategist.py
@@ -1,0 +1,70 @@
+import os
+import json
+import logging
+from pathlib import Path
+from datetime import datetime
+import asyncio
+
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+SYSTEM_PROMPT = (
+    "You are a trading strategist assistant. Analyze the following context and "
+    "return a clear trade recommendation in JSON format."
+)
+
+RETURN_INSTRUCTION = "Return JSON: { action, confidence (0-1), reason }"
+
+async def _call_openai(messages: list[dict]) -> str:
+    """Call OpenAI ChatCompletion API and return the message content."""
+    resp = await asyncio.to_thread(
+        openai.ChatCompletion.create,
+        model="gpt-3.5-turbo",
+        messages=messages,
+        temperature=0.2,
+    )
+    return resp["choices"][0]["message"]["content"].strip()
+
+
+def _log_decision(context: dict, decision: dict) -> None:
+    """Append AI decisions to log file."""
+    try:
+        Path("logs").mkdir(exist_ok=True)
+        log_path = Path("logs/ai_decisions.log")
+        line = f"{datetime.utcnow().isoformat()} context={json.dumps(context)} "
+        line += f"decision={json.dumps(decision)}\n"
+        with open(log_path, "a") as f:
+            f.write(line)
+    except Exception as e:
+        logging.error(f"Failed to log AI decision: {e}")
+
+
+async def get_ai_trade_decision(context: dict) -> dict:
+    """Analyze market context with GPT-3.5 and return a trade decision."""
+    enabled = os.getenv("ENABLE_AI_STRATEGY", "true").lower() in ("true", "1", "yes")
+    if not enabled:
+        return {"action": "hold", "confidence": 0.5, "reason": "AI disabled"}
+
+    if not openai.api_key:
+        logging.error("OPENAI_API_KEY not set")
+        return {"action": "hold", "confidence": 0.5, "reason": "No API key"}
+
+    user_content = "\n".join(f"{k}: {v}" for k, v in context.items())
+    user_content += f"\n\n{RETURN_INSTRUCTION}"
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    for attempt in range(3):
+        try:
+            text = await _call_openai(messages)
+            decision = json.loads(text)
+            _log_decision(context, decision)
+            return decision
+        except Exception as e:
+            logging.error(f"OpenAI call failed (attempt {attempt+1}): {e}")
+            await asyncio.sleep(2)
+
+    return {"action": "hold", "confidence": 0.5, "reason": "AI error"}


### PR DESCRIPTION
## Summary
- add `ai_strategist.py` service to query GPT-3.5 for trade recommendations
- load `OPENAI_API_KEY` and `ENABLE_AI_STRATEGY` env vars
- document AI env vars in README and .env example
- include `openai` in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684658d7f4808330a45a92451e81e3f4