### PR TITLE
Integrate AI strategist as trading signal engine

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -33,6 +33,7 @@ class ConfigManager:
         self.base_config['simulation_mode'] = os.getenv('SIMULATION_MODE', 'True').lower() in ('true', '1', 'yes')
         self.base_config['ENABLE_STOCK_TRADING'] = os.getenv('ENABLE_STOCK_TRADING', 'false').lower() in ('true', '1', 'yes')
         self.base_config['ENABLE_AI_STRATEGY'] = os.getenv('ENABLE_AI_STRATEGY', 'false').lower() in ('true', '1', 'yes')
+        self.base_config['LIVE_TRADING_ENABLED'] = os.getenv('LIVE_TRADING_ENABLED', 'true').lower() in ('true', '1', 'yes')
         self.base_config['log_level'] = os.getenv('LOG_LEVEL', 'INFO')
         self.base_config['db_path'] = os.getenv('DB_PATH', 'trades.db')
         self.base_config['config_path'] = os.getenv('CONFIG_PATH', 'config.json')

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -31,6 +31,7 @@ from utils import (
     PortfolioManager,
 )
 from config.config_manager import ConfigManager
+from services.ai_strategist import get_last_decision
 
 
 # Placeholder chart data for markets
@@ -116,6 +117,19 @@ def main():
 
     top[1].metric("Portfolio Equity", equity)
     top[2].metric("Open Risk", metrics.get("open_risk", 0.0))
+
+    decision = get_last_decision()
+    if decision:
+        conf = decision["decision"].get("confidence", 0.0)
+        color = "green" if conf >= 0.7 else "yellow" if conf >= 0.4 else "red"
+        st.markdown("### AI Strategist Last Decision")
+        st.markdown(
+            f"<span style='background-color:{color};color:white;padding:4px;border-radius:3px'>{decision['decision'].get('action')} ({conf:.2f})</span> - {decision['decision'].get('reason','')}",
+            unsafe_allow_html=True,
+        )
+    else:
+        st.markdown("### AI Strategist Last Decision")
+        st.write("No decision logged yet.")
 
     portfolio_tabs = st.tabs([
         "Simulated Portfolio",

--- a/services/ai_strategist.py
+++ b/services/ai_strategist.py
@@ -68,3 +68,26 @@ async def get_ai_trade_decision(context: dict) -> dict:
             await asyncio.sleep(2)
 
     return {"action": "hold", "confidence": 0.5, "reason": "AI error"}
+
+
+def get_last_decision(log_path: str = "logs/ai_decisions.log") -> dict:
+    """Return the most recent AI decision and context from log file."""
+    path = Path(log_path)
+    if not path.is_file():
+        return {}
+    try:
+        lines = path.read_text().strip().splitlines()
+        if not lines:
+            return {}
+        last = lines[-1]
+        ts_part, rest = last.split(" ", 1)
+        ctx_str = rest.split("context=")[1].split(" decision=")[0]
+        dec_str = rest.split("decision=")[1]
+        return {
+            "timestamp": ts_part,
+            "context": json.loads(ctx_str),
+            "decision": json.loads(dec_str),
+        }
+    except Exception as e:
+        logging.error(f"Failed to read last AI decision: {e}")
+        return {}

--- a/strategies/crypto/momentum.py
+++ b/strategies/crypto/momentum.py
@@ -2,9 +2,12 @@
 
 import asyncio
 import logging
-from signals import SignalGenerator, Signal
+from datetime import datetime
+import numpy as np
+
 from risk.risk import DynamicRisk
 from utils.helpers import parse_price
+from services.ai_strategist import get_ai_trade_decision
 
 class MomentumStrategy:
     def __init__(self, api, risk, config, db, symbol_list, sentiment_source=None):
@@ -16,7 +19,6 @@ class MomentumStrategy:
         self.sentiment_source = sentiment_source
         self.price_history = {symbol: [] for symbol in symbol_list}
         self.interval = 10  # seconds
-        self.signal_gen = SignalGenerator()
         self.dynamic_risk = DynamicRisk(risk,
                                        config.get("atr_period", 14),
                                        config.get("volatility_multiplier", 3))
@@ -33,10 +35,22 @@ class MomentumStrategy:
                         self.price_history[symbol] = self.price_history[symbol][-100:]
 
                     sentiment = await self.get_sentiment(symbol)
-                    signal = self.signal_gen.generate(self.price_history[symbol], sentiment)
+                    context = self._build_context(symbol, price, sentiment)
+                    decision = await get_ai_trade_decision(context)
 
-                    if signal.action != "hold" and signal.confidence > 0:
-                        await self.enter_trade(symbol, price, signal)
+                    if (
+                        decision.get("action") in ["buy", "sell"]
+                        and decision.get("confidence", 0) >= 0.7
+                    ):
+                        await self.enter_trade(
+                            symbol,
+                            price,
+                            decision.get("action"),
+                            decision.get("confidence", 0.0),
+                            decision.get("reason", "ai"),
+                        )
+                    else:
+                        logging.info(f"AI decision skipped: {decision}")
 
                 except Exception as e:
                     logging.error(f"[Momentum] Error on {symbol}: {e}")
@@ -57,39 +71,81 @@ class MomentumStrategy:
         news = scores.get("newsapi", {}).get("score", 0.0)
         return (cp + reddit_avg + news) / 3
 
-    async def enter_trade(self, symbol: str, price: float, signal: Signal):
+    def _build_context(self, symbol: str, price: float, sentiment: float) -> dict:
+        prices = self.price_history[symbol]
+        vol = float(np.std(np.diff(prices[-10:]))) if len(prices) > 2 else 0.0
+        trend = "sideways"
+        if len(prices) >= 5:
+            x = np.arange(5)
+            y = np.array(prices[-5:])
+            slope = np.polyfit(x, y, 1)[0]
+            if slope > 0:
+                trend = "uptrend"
+            elif slope < 0:
+                trend = "downtrend"
+        pos_qty = 0.0
+        if getattr(self.api, "portfolio", None):
+            pos_qty = self.api.portfolio.open_positions.get(symbol, 0.0)
+        status = "flat"
+        if pos_qty > 0:
+            status = "long"
+        elif pos_qty < 0:
+            status = "short"
+        support = min(prices[-20:]) if len(prices) >= 1 else price
+        resistance = max(prices[-20:]) if len(prices) >= 1 else price
+        return {
+            "symbol": symbol,
+            "price": price,
+            "volatility": round(vol, 6),
+            "sentiment": sentiment,
+            "position_status": status,
+            "recent_trend": trend,
+            "support": support,
+            "resistance": resistance,
+            "drawdown": self.risk.daily_loss,
+            "loss_streak": self.risk.consec_losses,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+    async def enter_trade(
+        self, symbol: str, price: float, action: str, confidence: float, reason: str
+    ):
         if not await self.risk.check_daily_loss():
             logging.warning("Daily loss limit reached. Trade blocked.")
             return
-        qty = self.dynamic_risk.position_size(price, signal.confidence, self.price_history[symbol])
+        qty = self.dynamic_risk.position_size(price, confidence, self.price_history[symbol])
         if qty <= 0:
             logging.warning("Momentum: invalid position size.")
             return
 
-        stops = self.dynamic_risk.stop_levels(price, signal.action, self.price_history[symbol])
+        stops = self.dynamic_risk.stop_levels(price, action, self.price_history[symbol])
         if stops.rr < 1.0:
             logging.info(f"Trade skipped on {symbol} due to RR {stops.rr:.2f}")
             return
 
+        if not self.config.get("simulation_mode", True) and not self.config.get("LIVE_TRADING_ENABLED", True):
+            logging.info("Live trading disabled. Trade skipped.")
+            return
+
         await self.api.place_order(
             product_id=symbol,
-            side=signal.action,
+            side=action,
             size=qty,
             order_type="market",
             price=price,
-            confidence=signal.confidence,
+            confidence=confidence,
         )
 
         self.db.log_trade(
             symbol=symbol,
-            side=signal.action,
+            side=action,
             quantity=qty,
             price=price,
             profit_loss=None,
-            reason=signal.details,
+            reason=reason,
             market="crypto",
         )
 
         logging.info(
-            f"{signal.action.upper()} {symbol} @ {price} conf={signal.confidence} RR={stops.rr:.2f} details={signal.details}"
+            f"{action.upper()} {symbol} @ {price} conf={confidence} RR={stops.rr:.2f} details={reason}"
         )

--- a/strategies/forex/rsi_trend.py
+++ b/strategies/forex/rsi_trend.py
@@ -1,7 +1,10 @@
 import asyncio
 import logging
+from datetime import datetime
+import numpy as np
 from indicators.technical_indicators import relative_strength_index
 from risk.risk import DynamicRisk
+from services.ai_strategist import get_ai_trade_decision
 
 class ForexRSITrendStrategy:
     """Simple RSI-based trend following strategy for Forex."""
@@ -31,20 +34,66 @@ class ForexRSITrendStrategy:
                     if len(self.price_history[symbol]) > 100:
                         self.price_history[symbol] = self.price_history[symbol][-100:]
 
-                    rsi = relative_strength_index(self.price_history[symbol])
-                    if rsi > 60:
-                        await self.enter_trade(symbol, price, "buy", rsi)
-                    elif rsi < 40:
-                        await self.enter_trade(symbol, price, "sell", rsi)
+                    context = self._build_context(symbol, price)
+                    decision = await get_ai_trade_decision(context)
+
+                    if (
+                        decision.get("action") in ["buy", "sell"]
+                        and decision.get("confidence", 0) >= 0.7
+                    ):
+                        await self.enter_trade(
+                            symbol,
+                            price,
+                            decision.get("action"),
+                            decision.get("confidence", 0.0),
+                            decision.get("reason", "ai"),
+                        )
+                    else:
+                        logging.info(f"AI decision skipped: {decision}")
                 except Exception as e:
                     logging.error(f"[RSITrend] Error for {symbol}: {e}")
             await asyncio.sleep(self.interval)
 
-    async def enter_trade(self, symbol, price, side, rsi):
-        confidence = abs(rsi - 50) / 50
+    def _build_context(self, symbol: str, price: float) -> dict:
+        prices = self.price_history[symbol]
+        vol = float(np.std(np.diff(prices[-10:]))) if len(prices) > 2 else 0.0
+        trend = "sideways"
+        if len(prices) >= 5:
+            x = np.arange(5)
+            y = np.array(prices[-5:])
+            slope = np.polyfit(x, y, 1)[0]
+            trend = "uptrend" if slope > 0 else "downtrend" if slope < 0 else "sideways"
+        status = "flat"
+        if getattr(self.api, "portfolio", None):
+            qty = self.api.portfolio.open_positions.get(symbol, 0.0)
+            if qty > 0:
+                status = "long"
+            elif qty < 0:
+                status = "short"
+        support = min(prices[-20:]) if prices else price
+        resistance = max(prices[-20:]) if prices else price
+        return {
+            "symbol": symbol,
+            "price": price,
+            "volatility": round(vol, 6),
+            "sentiment": 0.0,
+            "position_status": status,
+            "recent_trend": trend,
+            "support": support,
+            "resistance": resistance,
+            "drawdown": self.risk.daily_loss,
+            "loss_streak": self.risk.consec_losses,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+    async def enter_trade(self, symbol, price, side, confidence, reason):
         qty = self.dynamic_risk.position_size(price, confidence, self.price_history[symbol])
         if qty <= 0:
             logging.warning(f"RSITrend: invalid position size for {symbol}")
+            return
+
+        if not self.config.get("simulation_mode", True) and not self.config.get("LIVE_TRADING_ENABLED", True):
+            logging.info("Live trading disabled. Trade skipped.")
             return
 
         await self.api.place_order(
@@ -60,8 +109,10 @@ class ForexRSITrendStrategy:
             side=side,
             quantity=qty,
             price=price,
-            reason=f"rsi={rsi}",
+            reason=reason,
             market="forex",
         )
 
-        logging.info(f"{side.upper()} {symbol} @ {price} RSI={rsi} size={qty}")
+        logging.info(
+            f"{side.upper()} {symbol} @ {price} conf={confidence} reason={reason} size={qty}"
+        )

--- a/strategies/stocks/stock_momentum.py
+++ b/strategies/stocks/stock_momentum.py
@@ -2,7 +2,11 @@
 
 import asyncio
 import logging
+from datetime import datetime
+import numpy as np
+
 from indicators.technical_indicators import moving_average
+from services.ai_strategist import get_ai_trade_decision
 
 class StockMomentumStrategy:
     def __init__(self, api, risk, config, db, symbol_list):
@@ -23,19 +27,64 @@ class StockMomentumStrategy:
                     price = float(price_data.get("price") or price_data.get("last_trade_price", 0))
                     self.price_history[symbol].append(price)
 
-                    if len(self.price_history[symbol]) > self.ma_period:
-                        self.price_history[symbol] = self.price_history[symbol][-self.ma_period:]
-                        ma = moving_average(self.price_history[symbol], self.ma_period)
+                    if len(self.price_history[symbol]) > 100:
+                        self.price_history[symbol] = self.price_history[symbol][-100:]
 
-                        if price > ma * 1.02:
-                            await self.enter_trade(symbol, price, "buy")
+                    context = self._build_context(symbol, price)
+                    decision = await get_ai_trade_decision(context)
+
+                    if (
+                        decision.get("action") in ["buy", "sell"]
+                        and decision.get("confidence", 0) >= 0.7
+                    ):
+                        await self.enter_trade(
+                            symbol,
+                            price,
+                            decision.get("action"),
+                            decision.get("confidence", 0.0),
+                            decision.get("reason", "ai"),
+                        )
+                    else:
+                        logging.info(f"AI decision skipped: {decision}")
 
                 except Exception as e:
                     logging.error(f"[StockMomentum] Error for {symbol}: {e}")
 
             await asyncio.sleep(self.interval)
 
-    async def enter_trade(self, symbol, price, side):
+    def _build_context(self, symbol: str, price: float) -> dict:
+        prices = self.price_history[symbol]
+        vol = float(np.std(np.diff(prices[-10:]))) if len(prices) > 2 else 0.0
+        trend = "sideways"
+        if len(prices) >= 5:
+            x = np.arange(5)
+            y = np.array(prices[-5:])
+            slope = np.polyfit(x, y, 1)[0]
+            trend = "uptrend" if slope > 0 else "downtrend" if slope < 0 else "sideways"
+        status = "flat"
+        if getattr(self.api, "portfolio", None):
+            qty = self.api.portfolio.open_positions.get(symbol, 0.0)
+            if qty > 0:
+                status = "long"
+            elif qty < 0:
+                status = "short"
+        support = min(prices[-20:]) if prices else price
+        resistance = max(prices[-20:]) if prices else price
+        return {
+            "symbol": symbol,
+            "price": price,
+            "volatility": round(vol, 6),
+            "sentiment": 0.0,
+            "position_status": status,
+            "recent_trend": trend,
+            "support": support,
+            "resistance": resistance,
+            "drawdown": self.risk.daily_loss,
+            "loss_streak": self.risk.consec_losses,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+    async def enter_trade(self, symbol, price, side, confidence):
         if not await self.risk.check_daily_loss():
             logging.warning("Daily loss limit reached. Trade blocked.")
             return
@@ -44,13 +93,17 @@ class StockMomentumStrategy:
             logging.warning(f"StockMomentum: invalid position size for {symbol}")
             return
 
+        if not self.config.get("simulation_mode", True) and not self.config.get("LIVE_TRADING_ENABLED", True):
+            logging.info("Live trading disabled. Trade skipped.")
+            return
+
         await self.api.place_order(
             symbol=symbol,
             side=side,
             quantity=qty,
             order_type="market",
             price=price,
-            confidence=0.0,
+            confidence=confidence,
         )
 
         self.db.log_trade(
@@ -58,8 +111,10 @@ class StockMomentumStrategy:
             side=side,
             quantity=qty,
             price=price,
-            reason="momentum",
+            reason="ai",
             market="stocks"
         )
 
-        logging.info(f"{side.upper()} {symbol} @ {price} via momentum strategy")
+        logging.info(
+            f"{side.upper()} {symbol} @ {price} conf={confidence} via ai strategist"
+        )


### PR DESCRIPTION
## Summary
- load `LIVE_TRADING_ENABLED` flag from env
- expose helper to get last AI strategist decision
- switch momentum, stock and forex strategies to request trade actions from the AI
- log AI decisions and display the latest call on the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465c2d38a48330bf333b616a74abbd