### PR TITLE
Fix dashboard imports to handle execution from subdirectory

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2,6 +2,14 @@
 
 """Main entry for the Streamlit dashboard with real-time updates."""
 
+import os
+import sys
+
+# Ensure the project root is on the Python path when running this file
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
 import streamlit as st
 import datetime
 


### PR DESCRIPTION
## Summary
- ensure `dashboard/app.py` adds the project root to `sys.path`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846604069708330b564bf0b6121d845