### PR TITLE
Fix dashboard imports and utils package

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -25,7 +25,7 @@ from views import (
     show_portfolio_table,
     show_sim_summary,
 )
-from utils import (
+from dashboard.utils import (
     load_control_flags,
     auto_refresh,
     get_last_trade,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,16 @@
+from .guardrails import log_live_trade, confirm_live_mode
+from .helpers import round_price, format_timestamp, parse_price, safe_ratio
+from .logger import setup_logging
+from .notifications import send_slack_message, send_email
+
+__all__ = [
+    "log_live_trade",
+    "confirm_live_mode",
+    "round_price",
+    "format_timestamp",
+    "parse_price",
+    "safe_ratio",
+    "setup_logging",
+    "send_slack_message",
+    "send_email",
+]


### PR DESCRIPTION
## Summary
- make `utils` a proper Python package
- adjust dashboard imports to use dashboard.utils package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python launcher.py --simulate` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6846634e4b0c8330859c58c2765e0636