### PR TITLE
Fix OpenAI interface and coinbase auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # Coinbase
 COINBASE_API_KEY=your_coinbase_key
 COINBASE_SECRET_KEY=your_coinbase_secret
+COINBASE_PASSPHRASE=your_coinbase_passphrase
 
 # Robinhood (view-only)
 ROBINHOOD_API_KEY=

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -22,6 +22,7 @@ class ConfigManager:
         self.base_config['api_keys'] = {
             'coinbase': os.getenv('COINBASE_API_KEY'),
             'coinbase_secret': os.getenv('COINBASE_SECRET_KEY'),
+            'coinbase_passphrase': os.getenv('COINBASE_PASSPHRASE'),
             'alpaca': os.getenv('ALPACA_API_KEY'),
             'alpaca_secret': os.getenv('ALPACA_SECRET_KEY'),
             'alpaca_base_url': os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),

--- a/dashboard/utils/portfolio_manager.py
+++ b/dashboard/utils/portfolio_manager.py
@@ -30,6 +30,7 @@ class PortfolioManager:
                 api = CryptoAPI(
                     api_key=api_keys.get("coinbase"),
                     secret_key=api_keys.get("coinbase_secret", ""),
+                    passphrase=api_keys.get("coinbase_passphrase", ""),
                     simulation_mode=False,
                 )
                 data = await api.fetch_holdings()
@@ -107,6 +108,7 @@ class PortfolioManager:
             api = CryptoAPI(
                 api_key=api_keys.get("coinbase"),
                 secret_key=api_keys.get("coinbase_secret", ""),
+                passphrase=api_keys.get("coinbase_passphrase", ""),
                 simulation_mode=False,
             )
             data = await api.fetch_holdings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ textblob
 websockets
 python-dotenv
 alpaca-trade-api
-openai
+openai>=1.0

--- a/services/ai_strategist.py
+++ b/services/ai_strategist.py
@@ -23,13 +23,23 @@ RETURN_INSTRUCTION = "Return JSON: { action, confidence (0-1), reason }"
 
 async def _call_openai(messages: list[dict]) -> str:
     """Call OpenAI ChatCompletion API and return the message content."""
-    resp = await asyncio.to_thread(
-        openai.ChatCompletion.create,
-        model="gpt-3.5-turbo",
-        messages=messages,
-        temperature=0.2,
-    )
-    return resp["choices"][0]["message"]["content"].strip()
+    try:
+        resp = await asyncio.to_thread(
+            openai.chat.completions.create,
+            model="gpt-3.5-turbo",
+            messages=messages,
+            temperature=0.2,
+        )
+        return resp.choices[0].message.content.strip()
+    except AttributeError:
+        # Fallback for older openai<1.0
+        resp = await asyncio.to_thread(
+            openai.ChatCompletion.create,
+            model="gpt-3.5-turbo",
+            messages=messages,
+            temperature=0.2,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
 
 
 def _log_decision(context: dict, decision: dict) -> None:

--- a/services/bot_launcher.py
+++ b/services/bot_launcher.py
@@ -69,6 +69,7 @@ class BotLauncher:
         crypto_api = CryptoAPI(
             api_key=api_keys["coinbase"],
             secret_key=api_keys["coinbase_secret"],
+            passphrase=api_keys.get("coinbase_passphrase", ""),
             simulation_mode=self.config.get("simulation_mode", True),
             portfolio=self.sim_portfolio,
             config=self.config,


### PR DESCRIPTION
## Summary
- use new `openai.chat.completions.create` API
- support optional `COINBASE_PASSPHRASE`
- pass coinbase passphrase to bot and dashboard
- pin OpenAI library version

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68478dad9a88833097757346f3572b2d