### PR TITLE
Fix Coinbase import path

### DIFF
--- a/api/coinbase_client.py
+++ b/api/coinbase_client.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from typing import Any, Dict, Optional
 
-from coinbase.advanced_trade.client import AdvancedTradeClient
+from coinbase_advanced_trade import AdvancedTradeClient
 
 from utils.guardrails import log_live_trade
 


### PR DESCRIPTION
## Summary
- update coinbase_client to import `AdvancedTradeClient` from `coinbase_advanced_trade`

## Testing
- `python -m py_compile api/coinbase_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bbf0f79083308a3cbfb4598186e0