### PR TITLE
Fix Coinbase client import fallback

### DIFF
--- a/api/coinbase_client.py
+++ b/api/coinbase_client.py
@@ -7,7 +7,10 @@ import logging
 import uuid
 from typing import Any, Dict, Optional
 
-from coinbase_advanced_trade import AdvancedTradeClient
+try:  # Preferred modern SDK
+    from coinbase_advanced_trade import AdvancedTradeClient
+except ModuleNotFoundError:  # Fall back to official coinbase-advanced-py SDK
+    from coinbase.rest import RESTClient as AdvancedTradeClient
 
 from utils.guardrails import log_live_trade
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ python-dotenv
 openai>=1.0
 pytrends
 coinbase-advanced-py
-coinbase-advanced-trade
+# Optional new SDK name; fallback handled in code
+coinbase-advancedtrade-python


### PR DESCRIPTION
## Summary
- support multiple Coinbase SDK module names
- install the modern Coinbase SDK in requirements

## Testing
- `python -m py_compile api/coinbase_client.py`

------
https://chatgpt.com/codex/tasks/task_e_684b97d552b083308665669dc5ad26fd