### PR TITLE
Add advanced backtest engine and strategies

### DIFF
--- a/backtest/backtest_engine.py
+++ b/backtest/backtest_engine.py
@@ -1,36 +1,139 @@
 import pandas as pd
+import numpy as np
 import logging
-from typing import Callable, List, Dict
+from dataclasses import dataclass
+from typing import Callable, List, Dict, Optional
+from pathlib import Path
+
+
+@dataclass
+class Trade:
+    """Simple trade container for backtest results."""
+
+    entry_time: pd.Timestamp
+    exit_time: Optional[pd.Timestamp]
+    entry_price: float
+    exit_price: Optional[float]
+    size: float
+    pnl: Optional[float] = None
+
+
+class RiskManager:
+    """Handle position sizing based on equity and risk percent."""
+
+    def __init__(self, risk_pct: float = 0.01):
+        self.risk_pct = risk_pct
+
+    def get_size(self, equity: float, price: float) -> float:
+        dollar_risk = equity * self.risk_pct
+        if price <= 0:
+            return 0.0
+        return round(dollar_risk / price, 8)
 
 class BacktestEngine:
-    """Very simple backtesting engine using historical price data."""
+    """Backtesting engine with basic risk management and reporting."""
 
-    def __init__(self, prices: pd.DataFrame, strategy_fn: Callable[[List[float]], str]):
+    REQUIRED_COLS = {"open", "high", "low", "close", "volume"}
+
+    def __init__(
+        self,
+        prices: pd.DataFrame,
+        strategy_fn: Callable[[List[float]], str],
+        initial_balance: float = 10_000.0,
+        risk_pct: float = 0.01,
+        slippage: float = 0.0005,
+        commission: float = 0.001,
+        results_dir: str = "backtest/results",
+    ) -> None:
+        if not BacktestEngine.REQUIRED_COLS.issubset(prices.columns):
+            raise ValueError(
+                f"prices DataFrame must contain columns {BacktestEngine.REQUIRED_COLS}"
+            )
+        if not isinstance(prices.index, pd.DatetimeIndex):
+            raise ValueError("prices index must be DatetimeIndex")
+
         self.prices = prices
         self.strategy_fn = strategy_fn
-        self.trades = []
-        self.equity = 1.0
+        self.balance = float(initial_balance)
+        self.risk = RiskManager(risk_pct)
+        self.slippage = slippage
+        self.commission = commission
+        self.results_dir = Path(results_dir)
 
-    def run(self):
+        self.trades: List[Trade] = []
+        self.open_trade: Optional[Trade] = None
+        self.equity_curve: List[float] = []
+
+    def run(self) -> None:
         history: List[float] = []
         for ts, row in self.prices.iterrows():
-            price = row["close"]
+            price = float(row["close"])
             history.append(price)
+
+            if self.open_trade:
+                open_pnl = (price - self.open_trade.entry_price) * self.open_trade.size
+                equity = self.balance + open_pnl
+            else:
+                equity = self.balance
+            self.equity_curve.append(equity)
+
             signal = self.strategy_fn(history)
-            if signal == "buy":
-                self.trades.append({"type": "buy", "price": price})
-            elif signal == "sell" and self.trades:
-                entry = self.trades[-1]["price"]
-                pnl = price / entry - 1
-                self.equity *= 1 + pnl
-                self.trades.append({"type": "sell", "price": price, "pnl": pnl})
-                logging.info(f"Trade closed pnl={pnl:.3f}")
+
+            if signal == "buy" and self.open_trade is None:
+                size = self.risk.get_size(equity, price)
+                if size > 0:
+                    entry = price * (1 + self.slippage)
+                    cost = entry * size * (1 + self.commission)
+                    self.balance -= cost
+                    self.open_trade = Trade(ts, None, entry, None, size)
+            elif signal == "sell" and self.open_trade is not None:
+                exit_price = price * (1 - self.slippage)
+                pnl = (exit_price - self.open_trade.entry_price) * self.open_trade.size
+                fees = (exit_price * self.open_trade.size) * self.commission
+                self.balance += exit_price * self.open_trade.size - fees
+                self.open_trade.exit_time = ts
+                self.open_trade.exit_price = exit_price
+                self.open_trade.pnl = pnl - (self.open_trade.entry_price * self.open_trade.size * self.commission)
+                self.trades.append(self.open_trade)
+                logging.info(f"Trade closed pnl={self.open_trade.pnl:.2f}")
+                self.open_trade = None
+
+        self._save_results()
+
+    def _save_results(self) -> None:
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame({"equity": self.equity_curve}, index=self.prices.index[: len(self.equity_curve)])
+        path = self.results_dir / "backtest_results.csv"
+        df.to_csv(path)
 
     def summary(self) -> Dict:
-        wins = [t for t in self.trades if t.get("pnl", 0) > 0]
-        losses = [t for t in self.trades if t.get("pnl", 0) <= 0]
+        if not self.equity_curve:
+            return {}
+
+        equity = self.equity_curve[-1]
+        pnl_list = [t.pnl for t in self.trades if t.pnl is not None]
+        wins = [p for p in pnl_list if p > 0]
+        losses = [p for p in pnl_list if p <= 0]
+        daily_returns = np.diff(self.equity_curve) / self.equity_curve[:-1]
+        max_drawdown = 0.0
+        peak = self.equity_curve[0]
+        for val in self.equity_curve:
+            if val > peak:
+                peak = val
+            dd = (peak - val) / peak
+            max_drawdown = max(max_drawdown, dd)
+        sharpe = 0.0
+        if daily_returns.size > 1 and np.std(daily_returns) != 0:
+            sharpe = (np.mean(daily_returns) - 0.02) / np.std(daily_returns)
+        profit_factor = abs(sum(wins)) / abs(sum(losses)) if losses else float('inf')
+
         return {
-            "equity": self.equity,
-            "trades": len(self.trades) // 2,
+            "equity": equity,
+            "trades": len(pnl_list),
             "win_rate": len(wins) / max(len(wins) + len(losses), 1),
+            "avg_gain": np.mean(wins) if wins else 0.0,
+            "avg_loss": np.mean(losses) if losses else 0.0,
+            "profit_factor": profit_factor,
+            "sharpe_ratio": sharpe,
+            "max_drawdown": max_drawdown,
         }

--- a/backtest/backtest_runner.py
+++ b/backtest/backtest_runner.py
@@ -6,18 +6,20 @@ from backtest.backtest_engine import BacktestEngine
 
 def run_backtest(strategy_cls: Type, csv_path: str) -> dict:
     """Load price CSV and run strategy on historical closes."""
-    df = pd.read_csv(csv_path)
-    if 'close' not in df.columns:
-        raise ValueError('CSV must contain close column')
+    df = pd.read_csv(csv_path, parse_dates=[0])
+    required = {'open', 'high', 'low', 'close', 'volume'}
+    if not required.issubset(df.columns):
+        raise ValueError(f'CSV must contain columns {required}')
 
-    def strategy_fn(prices):
-        strat = strategy_cls(None, None, {}, None, [])  # simplified instance
-        # use strategy's logic on history if method available
+    df.set_index(df.columns[0], inplace=True)
+
+    def strategy_fn(history):
+        strat = strategy_cls(None, None, {}, None, ['TEST'])  # simple instance
         if hasattr(strat, 'generate_signal'):
-            return strat.generate_signal(prices)
+            return strat.generate_signal(history)
         return 'hold'
 
-    engine = BacktestEngine(df[['close']], strategy_fn)
+    engine = BacktestEngine(df, strategy_fn)
     engine.run()
     summary = engine.summary()
     logging.info(f"Backtest complete: {summary}")

--- a/services/ai_strategist.py
+++ b/services/ai_strategist.py
@@ -182,3 +182,12 @@ async def ai_discover_assets(base_symbols: list[str] | None = None) -> list[str]
     except Exception as e:
         logging.error(f"AI asset discovery failed: {e}")
         return []
+
+
+async def get_conviction_score(context: dict) -> float:
+    """Return a conviction score between 0 and 1 using GPT if available."""
+    try:
+        decision = await get_ai_trade_decision(context)
+        return float(decision.get("confidence", 0.5))
+    except Exception:
+        return 0.5

--- a/signals/sentiment_manager.py
+++ b/signals/sentiment_manager.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+SENTIMENT_PATH = Path("dashboard/data/sentiment_cache.json")
+
+
+def get_sentiment_score(symbol: str) -> float:
+    """Return sentiment score for a symbol from cache, or 0.0 if unavailable."""
+    if not SENTIMENT_PATH.is_file():
+        return 0.0
+    try:
+        data = json.loads(SENTIMENT_PATH.read_text())
+        return data.get("cryptopanic", {}).get(symbol, {}).get("score", 0.0)
+    except Exception:
+        return 0.0

--- a/strategies/ai_momentum_fusion.py
+++ b/strategies/ai_momentum_fusion.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+from services.ai_strategist import get_conviction_score
+from signals.sentiment_manager import get_sentiment_score
+
+
+class AIMomentumFusion:
+    """AI-Driven momentum strategy combining sentiment and conviction."""
+
+    def __init__(self, api, risk, config, db, symbols):
+        self.config = config or {}
+        self.gpt4o_enabled = self.config.get("gpt4o_enabled", False)
+        self.min_conviction = self.config.get("min_conviction_score", 0.7)
+        self.window = self.config.get("momentum_window", 3)
+        self.in_position = False
+        self.symbol = symbols[0] if symbols else "BTC-USD"
+
+    def _ai_score(self, context: dict) -> float:
+        if not self.gpt4o_enabled:
+            return 0.5
+        try:
+            return asyncio.run(get_conviction_score(context))
+        except Exception:
+            return 0.5
+
+    def generate_signal(self, history: List[float]) -> str:
+        if len(history) <= self.window:
+            return "hold"
+        momentum = (history[-1] - history[-self.window]) / history[-self.window]
+        sentiment = get_sentiment_score(self.symbol)
+        score = self._ai_score({"momentum": momentum, "sentiment": sentiment})
+
+        if self.in_position:
+            if momentum <= 0 or score < self.min_conviction or sentiment <= 0:
+                self.in_position = False
+                return "sell"
+            return "hold"
+        else:
+            if momentum > 0 and score >= self.min_conviction and sentiment > 0:
+                self.in_position = True
+                return "buy"
+        return "hold"

--- a/strategies/crypto_scalper.py
+++ b/strategies/crypto_scalper.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import List
+
+from indicators.technical_indicators import relative_strength_index
+
+
+class CryptoScalper:
+    """Simple RSI based micro-scalping strategy."""
+
+    def __init__(self, api, risk, config, db, symbols):
+        self.config = config or {}
+        self.rsi_threshold = self.config.get("scalp_rsi_buy_threshold", 30)
+        self.profit_target = self.config.get("scalp_profit_target_pct", 0.75) / 100
+        self.timeout = self.config.get("scalp_timeout_minutes", 10)
+        self.in_position = False
+        self.entry_price = 0.0
+        self.entry_index = 0
+
+    def generate_signal(self, history: List[float]) -> str:
+        if self.in_position:
+            hold_time = len(history) - self.entry_index
+            if (
+                history[-1] >= self.entry_price * (1 + self.profit_target)
+                or hold_time >= self.timeout
+            ):
+                self.in_position = False
+                return "sell"
+            return "hold"
+
+        if len(history) < 15:
+            return "hold"
+        rsi = relative_strength_index(history, 14)
+        if rsi < self.rsi_threshold and history[-1] > history[-2] and history[-1] > history[-2] and history[-1] > 0:
+            self.in_position = True
+            self.entry_price = history[-1]
+            self.entry_index = len(history)
+            return "buy"
+        return "hold"


### PR DESCRIPTION
## Summary
- upgrade backtest engine with risk sizing and metrics
- add simple sentiment manager
- add AI momentum fusion strategy
- add crypto scalper strategy
- update runner to validate columns
- expose `get_conviction_score` helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bb18b7cd483308079b2832be89795