### PR TITLE
Add advanced sentiment analysis module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,9 @@ pytrends
 coinbase-advanced-py
 # Optional new SDK name; fallback handled in code
 coinbase-advancedtrade-python
+praw
+snscrape
+newsapi-python
+gnews
+transformers
+torch

--- a/sentiment/__init__.py
+++ b/sentiment/__init__.py
@@ -1,0 +1,1 @@
+"""Sentiment analysis package."""

--- a/sentiment/model.py
+++ b/sentiment/model.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Sentiment model utilities."""
+
+from functools import lru_cache
+from typing import Iterable, List, Dict
+from transformers import pipeline
+
+# Default HuggingFace model for financial sentiment
+DEFAULT_MODEL = "ProsusAI/finbert"
+
+@lru_cache()
+def get_sentiment_pipeline(model_name: str = DEFAULT_MODEL):
+    """Return a cached sentiment-analysis pipeline."""
+    return pipeline("sentiment-analysis", model=model_name)
+
+
+def analyze_texts(texts: Iterable[str], model_name: str = DEFAULT_MODEL) -> List[Dict[str, float]]:
+    """Run sentiment analysis on a list of texts."""
+    nlp = get_sentiment_pipeline(model_name)
+    clean_texts = [t.replace("\n", " ").strip() for t in texts if t and t.strip()]
+    if not clean_texts:
+        return []
+    return nlp(clean_texts)
+
+
+def label_to_score(label: str, score: float) -> float:
+    """Convert a model label and confidence to a [-1, 1] score."""
+    label = label.lower()
+    if label == "positive":
+        val = score
+    elif label == "negative":
+        val = -score
+    else:
+        val = 0.0
+    return val

--- a/sentiment/news_sentiment.py
+++ b/sentiment/news_sentiment.py
@@ -1,0 +1,57 @@
+"""News headline sentiment via GNews or NewsAPI."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Dict
+import os
+
+try:
+    from gnews import GNews
+except Exception:  # library not installed
+    GNews = None
+
+try:
+    from newsapi import NewsApiClient
+except Exception:
+    NewsApiClient = None
+
+from .model import analyze_texts, label_to_score
+
+
+class NewsSentiment:
+    """Fetch news articles and run sentiment analysis."""
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.getenv("NEWSAPI_KEY")
+        if self.api_key and NewsApiClient:
+            self.client = NewsApiClient(api_key=self.api_key)
+        else:
+            self.client = None
+        self.gnews = GNews() if GNews else None
+
+    def fetch_headlines(self, ticker: str, limit: int = 10) -> List[str]:
+        texts: List[str] = []
+        if self.client:
+            data = self.client.get_everything(q=ticker, language="en", sort_by="publishedAt", page_size=limit)
+            texts.extend([f"{a.get('title', '')} {a.get('description', '')}" for a in data.get('articles', [])])
+        elif self.gnews:
+            results = self.gnews.get_news(ticker)[:limit]
+            texts.extend([f"{a.get('title', '')} {a.get('description', '')}" for a in results])
+        return texts
+
+    def analyze(self, ticker: str, limit: int = 10) -> Dict:
+        texts = self.fetch_headlines(ticker, limit)
+        results = analyze_texts(texts)
+        scores = [label_to_score(r['label'], r['score']) for r in results]
+        avg = sum(scores) / len(scores) if scores else 0.0
+        label = "neutral"
+        if avg > 0.1:
+            label = "positive"
+        elif avg < -0.1:
+            label = "negative"
+        return {
+            "score": round((avg + 1) / 2, 3),
+            "label": label,
+            "count": len(scores),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }

--- a/sentiment/reddit_sentiment.py
+++ b/sentiment/reddit_sentiment.py
@@ -1,0 +1,54 @@
+"""Reddit sentiment scraping using PRAW."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Dict
+import os
+import logging
+import praw
+
+from .model import analyze_texts, label_to_score
+
+
+class RedditSentiment:
+    """Fetch posts and comments from a subreddit and run sentiment analysis."""
+
+    def __init__(self, client_id: str | None = None, client_secret: str | None = None, user_agent: str | None = None):
+        self.client_id = client_id or os.getenv("REDDIT_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("REDDIT_CLIENT_SECRET")
+        self.user_agent = user_agent or os.getenv("REDDIT_USER_AGENT", "LysaraSentimentBot")
+        self.reddit = praw.Reddit(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            user_agent=self.user_agent,
+            check_for_async=False,
+        )
+
+    def fetch_texts(self, subreddit: str, ticker: str, limit: int = 20) -> List[str]:
+        """Gather submission titles and comments mentioning the ticker."""
+        texts: List[str] = []
+        query = ticker.upper()
+        for submission in self.reddit.subreddit(subreddit).search(query, limit=limit, sort="top", time_filter="day"):
+            texts.append(f"{submission.title} {submission.selftext}")
+            submission.comments.replace_more(limit=0)
+            for comment in submission.comments.list():
+                if query in comment.body.upper():
+                    texts.append(comment.body)
+        return texts
+
+    def analyze(self, subreddit: str, ticker: str, limit: int = 20) -> Dict:
+        texts = self.fetch_texts(subreddit, ticker, limit)
+        results = analyze_texts(texts)
+        scores = [label_to_score(r['label'], r['score']) for r in results]
+        avg = sum(scores) / len(scores) if scores else 0.0
+        label = "neutral"
+        if avg > 0.1:
+            label = "positive"
+        elif avg < -0.1:
+            label = "negative"
+        return {
+            "score": round((avg + 1) / 2, 3),  # convert to 0-1 scale
+            "label": label,
+            "count": len(scores),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }

--- a/sentiment/sentiment_handler.py
+++ b/sentiment/sentiment_handler.py
@@ -1,0 +1,57 @@
+"""Aggregate sentiment from multiple sources into a Sentiment Confidence Score."""
+from __future__ import annotations
+
+from typing import Dict
+from datetime import datetime, timezone
+
+from .reddit_sentiment import RedditSentiment
+from .twitter_sentiment import analyze_twitter_sentiment
+from .news_sentiment import NewsSentiment
+
+
+class SentimentHandler:
+    """Interface used by strategies and services to obtain a sentiment score."""
+
+    def __init__(self, weights: Dict[str, float] | None = None, subreddits: list[str] | None = None, news_api_key: str | None = None):
+        self.weights = weights or {"twitter": 0.3, "reddit": 0.2, "news": 0.5}
+        self.subreddits = subreddits or ["stocks", "cryptocurrency"]
+        self.reddit = RedditSentiment()
+        self.news = NewsSentiment(api_key=news_api_key)
+
+    def _combine(self, results: Dict[str, Dict]) -> Dict:
+        """Combine individual source scores into a final SCS."""
+        total = 0.0
+        weight_sum = 0.0
+        for src, res in results.items():
+            w = self.weights.get(src, 0)
+            count = res.get("count", 1)
+            w = w * min(1.0, count / 10.0)  # volume adjustment
+            total += res.get("score", 0) * w
+            weight_sum += w
+        score = total / weight_sum if weight_sum else 0.0
+        label = "neutral"
+        if score > 0.6:
+            label = "positive"
+        elif score < 0.4:
+            label = "negative"
+        return {"score": round(score, 3), "label": label, "sources": results}
+
+    def get_sentiment_score(self, ticker: str) -> Dict:
+        """Public method to compute the sentiment score for a ticker."""
+        results: Dict[str, Dict] = {}
+        results["twitter"] = analyze_twitter_sentiment(ticker)
+        reddit_scores = []
+        for sub in self.subreddits:
+            reddit_scores.append(self.reddit.analyze(sub, ticker))
+        if reddit_scores:
+            avg_score = sum(r["score"] for r in reddit_scores) / len(reddit_scores)
+            avg_count = sum(r["count"] for r in reddit_scores)
+            results["reddit"] = {
+                "score": avg_score,
+                "count": avg_count,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "label": "positive" if avg_score > 0.6 else "negative" if avg_score < 0.4 else "neutral",
+            }
+        results["news"] = self.news.analyze(ticker)
+        return self._combine(results)
+

--- a/sentiment/twitter_sentiment.py
+++ b/sentiment/twitter_sentiment.py
@@ -1,0 +1,37 @@
+"""Twitter sentiment scraping using snscrape."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import snscrape.modules.twitter as sntwitter
+
+from .model import analyze_texts, label_to_score
+
+
+def fetch_tweets(ticker: str, limit: int = 50) -> List[str]:
+    """Collect recent tweets mentioning the given ticker."""
+    query = f"{ticker}"
+    texts: List[str] = []
+    for i, tweet in enumerate(sntwitter.TwitterSearchScraper(query).get_items()):
+        texts.append(tweet.content)
+        if i + 1 >= limit:
+            break
+    return texts
+
+
+def analyze_twitter_sentiment(ticker: str, limit: int = 50) -> Dict:
+    tweets = fetch_tweets(ticker, limit)
+    results = analyze_texts(tweets)
+    scores = [label_to_score(r['label'], r['score']) for r in results]
+    avg = sum(scores) / len(scores) if scores else 0.0
+    label = "neutral"
+    if avg > 0.1:
+        label = "positive"
+    elif avg < -0.1:
+        label = "negative"
+    return {
+        "score": round((avg + 1) / 2, 3),
+        "label": label,
+        "count": len(scores),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }


### PR DESCRIPTION
## Summary
- add new `/sentiment` package for multi-source sentiment scoring
- implement Reddit, Twitter and News sentiment modules with FinBERT
- aggregate scores in `SentimentHandler`
- update `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da080240c8330ba8802440a596292