### PR TITLE
Add advanced sentiment and strategy scaffolding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,9 @@ newsapi-python
 gnews
 transformers
 torch
+ta
+xgboost
+spacy
+google-trends-api
+youtube-transcript-api
+whisper

--- a/sentiment/alternative_data.py
+++ b/sentiment/alternative_data.py
@@ -1,0 +1,21 @@
+"""Alternative data sources for sentiment."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+# TODO: integrate actual APIs for these sources
+
+def youtube_sentiment(video_id: str) -> Dict:
+    """Placeholder for YouTube transcript sentiment."""
+    return {"video": video_id, "score": 0.0, "label": "neutral"}
+
+
+def google_trends(keyword: str) -> List[int]:
+    """Placeholder for Google Trends interest."""
+    return []
+
+
+def earnings_call_sentiment(ticker: str) -> Dict:
+    """Placeholder for earnings call transcript sentiment."""
+    return {"ticker": ticker, "score": 0.0, "label": "neutral"}
+

--- a/sentiment/context_aware.py
+++ b/sentiment/context_aware.py
@@ -1,0 +1,23 @@
+"""Macro aware sentiment adjustments."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import json
+from typing import Dict
+
+
+def load_macro_calendar(path: str | Path = "data/macro_event_calendar.json") -> Dict:
+    """Load macro event calendar from JSON file."""
+    if Path(path).exists():
+        return json.loads(Path(path).read_text())
+    return {}
+
+
+def adjust_for_macro(score: float, calendar: Dict, date: datetime) -> float:
+    """Reduce score around major macro events."""
+    events = calendar.get(date.strftime("%Y-%m-%d"), [])
+    if events:
+        return score * 0.8
+    return score
+

--- a/sentiment/feedback_loop.py
+++ b/sentiment/feedback_loop.py
@@ -1,0 +1,20 @@
+"""Feedback loop for sentiment driven trades."""
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Dict
+
+LOG_FILE = Path("logs/sentiment_performance.json")
+
+
+def log_trade_result(ticker: str, success: bool) -> None:
+    """Append trade outcome to log."""
+    LOG_FILE.parent.mkdir(exist_ok=True)
+    data = []
+    if LOG_FILE.exists():
+        data = json.loads(LOG_FILE.read_text())
+    data.append({"time": datetime.utcnow().isoformat(), "ticker": ticker, "success": success})
+    LOG_FILE.write_text(json.dumps(data, indent=2))
+

--- a/sentiment/global_sentiment.py
+++ b/sentiment/global_sentiment.py
@@ -1,0 +1,18 @@
+"""Multilingual sentiment scraping support."""
+from __future__ import annotations
+
+from typing import List, Dict
+
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - transformers optional
+    pipeline = None
+
+
+def analyze_texts(texts: List[str], lang: str = "en") -> List[Dict]:
+    """Return sentiment labels using a multilingual model."""
+    if pipeline is None:
+        return [{"label": "neutral", "score": 0.0} for _ in texts]
+    model = pipeline("sentiment-analysis", model="xlm-roberta-base")
+    return [dict(r) for r in model(texts)]
+

--- a/sentiment/historical_correlation.py
+++ b/sentiment/historical_correlation.py
@@ -1,0 +1,30 @@
+"""Correlation of sentiment spikes with historical price movements."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import json
+from typing import List
+
+import pandas as pd
+
+
+ndefault_file = Path("data/sentiment_sensitivity.json")
+
+
+def compute_correlation(sentiment_series: pd.Series, price_series: pd.Series) -> float:
+    """Return correlation between sentiment and price change."""
+    if len(sentiment_series) < 2 or len(price_series) < 2:
+        return 0.0
+    return float(sentiment_series.corr(price_series))
+
+
+def save_sensitivity(ticker: str, value: float, file_path: Path = ndefault_file) -> None:
+    """Persist the sentiment sensitivity for a ticker."""
+    file_path.parent.mkdir(exist_ok=True)
+    data = {}
+    if file_path.exists():
+        data = json.loads(file_path.read_text())
+    data[ticker] = value
+    file_path.write_text(json.dumps(data, indent=2))
+

--- a/sentiment/ner_event_tagging.py
+++ b/sentiment/ner_event_tagging.py
@@ -1,0 +1,28 @@
+"""Named entity and event tagging utilities."""
+from __future__ import annotations
+
+from typing import List, Dict
+import re
+
+try:
+    import spacy
+    nlp = spacy.load("en_core_web_sm")
+except Exception:  # pragma: no cover - spaCy model may not be present
+    nlp = None
+
+EVENT_PATTERNS = {
+    "layoff": re.compile(r"\blayoff(s)?\b", re.I),
+    "dividend": re.compile(r"\bdividend\b", re.I),
+    "merger": re.compile(r"\bmerger|acquisition\b", re.I),
+}
+
+
+def tag_entities(text: str) -> Dict:
+    """Return detected entities and event tags for the given text."""
+    entities: List[str] = []
+    if nlp:
+        doc = nlp(text)
+        entities = [ent.text for ent in doc.ents if ent.label_ in {"PERSON", "ORG"}]
+    events = [name for name, pat in EVENT_PATTERNS.items() if pat.search(text)]
+    return {"entities": entities, "events": events}
+

--- a/sentiment/sentiment_api_wrapper.py
+++ b/sentiment/sentiment_api_wrapper.py
@@ -1,0 +1,20 @@
+"""Unified sentiment API wrapper."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .sentiment_handler import SentimentHandler
+from .volatility_detector import compute_volatility
+from .feedback_loop import log_trade_result
+
+
+handler = SentimentHandler()
+
+
+def get_sentiment_score(ticker: str) -> Dict:
+    """Return structured sentiment information for a ticker."""
+    result = handler.get_sentiment_score(ticker)
+    volatility = compute_volatility({"score": result["score"]})
+    result["volatility"] = volatility
+    return result
+

--- a/sentiment/smart_filters.py
+++ b/sentiment/smart_filters.py
@@ -1,0 +1,21 @@
+"""Filtering helpers for sentiment sources."""
+from __future__ import annotations
+
+from typing import List, Set, Dict
+
+
+def filter_accounts(items: List[Dict], whitelist: Set[str] | None = None, blacklist: Set[str] | None = None) -> List[Dict]:
+    """Remove spam/bot accounts based on follower/karma counts."""
+    whitelist = whitelist or set()
+    blacklist = blacklist or set()
+    filtered: List[Dict] = []
+    for item in items:
+        user = item.get("user", "")
+        followers = item.get("followers", 0)
+        karma = item.get("karma", 0)
+        if user in blacklist:
+            continue
+        if user in whitelist or followers >= 20 or karma >= 30:
+            filtered.append(item)
+    return filtered
+

--- a/sentiment/time_decay.py
+++ b/sentiment/time_decay.py
@@ -1,0 +1,15 @@
+"""Utility for applying exponential time decay to sentiment scores."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from math import exp
+
+
+def decay_score(score: float, timestamp: datetime, half_life_hours: float) -> float:
+    """Return the score after applying exponential decay based on age."""
+    age_hours = (datetime.utcnow() - timestamp).total_seconds() / 3600
+    if half_life_hours <= 0:
+        return score
+    factor = 0.5 ** (age_hours / half_life_hours)
+    return score * factor
+

--- a/sentiment/visualizer.py
+++ b/sentiment/visualizer.py
@@ -1,0 +1,14 @@
+"""Streamlit dashboards for sentiment visualization."""
+from __future__ import annotations
+
+import streamlit as st
+import pandas as pd
+
+
+def show_heatmap(data: pd.DataFrame) -> None:
+    """Display a simple heatmap of sentiment scores."""
+    st.title("Sentiment Heatmap")
+    st.dataframe(data)
+
+
+# TODO: Add more detailed visualizations

--- a/sentiment/volatility_detector.py
+++ b/sentiment/volatility_detector.py
@@ -1,0 +1,14 @@
+"""Detect sentiment volatility across data sources."""
+from __future__ import annotations
+
+from typing import Dict, List
+import statistics
+
+
+def compute_volatility(sentiments: Dict[str, float]) -> float:
+    """Return standard deviation of sentiment scores as a simple volatility index."""
+    values: List[float] = list(sentiments.values())
+    if len(values) < 2:
+        return 0.0
+    return statistics.stdev(values)
+

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,18 @@
+# Default configuration for Lysara Investments AI Trading Engine
+
+sentiment:
+  twitter_half_life: 6  # hours
+  reddit_half_life: 12  # hours
+  news_half_life: 24  # hours
+  macro_suppression: 0.2
+  whitelist: []
+  blacklist: []
+
+risk:
+  max_daily_loss_pct: 5
+  drawdown_disable_pct: 20
+
+trading:
+  tickers: ["AAPL", "MSFT", "TSLA"]
+  position_size_pct: 0.02
+

--- a/strategy/ai_trade_oracle.py
+++ b/strategy/ai_trade_oracle.py
@@ -1,0 +1,26 @@
+"""Neural net trade direction classifier."""
+from __future__ import annotations
+
+from typing import Dict
+
+try:
+    from xgboost import XGBClassifier
+except Exception:  # pragma: no cover - xgboost optional
+    XGBClassifier = None
+
+
+class AITradeOracle:
+    """Simple wrapper around an XGBoost classifier."""
+
+    def __init__(self) -> None:
+        self.model = XGBClassifier() if XGBClassifier else None
+
+    def predict(self, features) -> Dict:
+        """Return dummy prediction for now."""
+        if not self.model:
+            return {"action": "hold", "confidence": 0.0}
+        # TODO: train model with proper dataset
+        pred = self.model.predict_proba([features])[0]
+        action = ["buy", "hold", "short"][pred.argmax()]
+        return {"action": action, "confidence": float(pred.max())}
+

--- a/strategy/news_trend_watcher.py
+++ b/strategy/news_trend_watcher.py
@@ -1,0 +1,12 @@
+"""Detect macro trend changes from news frequency."""
+from __future__ import annotations
+
+from collections import Counter
+from typing import List, Dict
+
+
+def detect_trends(words: List[str]) -> Dict[str, int]:
+    """Return simple word frequency counts."""
+    counts = Counter(word.lower() for word in words)
+    return dict(counts)
+

--- a/strategy/profit_guardrails.py
+++ b/strategy/profit_guardrails.py
@@ -1,0 +1,18 @@
+"""Safety checks for trading profits and drawdowns."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GuardrailState:
+    daily_pl: float = 0.0
+    disabled: bool = False
+
+
+def update(state: GuardrailState, pnl: float, cfg: dict) -> None:
+    """Update state with new trade PnL and enforce thresholds."""
+    state.daily_pl += pnl
+    if state.daily_pl <= -cfg.get("max_daily_loss_pct", 5) / 100:
+        state.disabled = True
+

--- a/strategy/signal_backtester.py
+++ b/strategy/signal_backtester.py
@@ -1,0 +1,21 @@
+"""Backtest sentiment + TA signals."""
+from __future__ import annotations
+
+from typing import List, Dict
+import pandas as pd
+
+
+def backtest(df: pd.DataFrame, signal: pd.Series) -> Dict:
+    """Very simple backtest using signal as position indicator."""
+    returns = df["close"].pct_change().fillna(0)
+    strat_returns = returns * signal.shift(1).fillna(0)
+    equity_curve = (1 + strat_returns).cumprod()
+    win_pct = (strat_returns > 0).mean()
+    total_return = equity_curve.iloc[-1] - 1
+    sharpe = (strat_returns.mean() / strat_returns.std()) * (252 ** 0.5) if strat_returns.std() else 0
+    return {
+        "win_pct": float(win_pct),
+        "total_return": float(total_return),
+        "sharpe": float(sharpe),
+    }
+

--- a/strategy/technical_alignment.py
+++ b/strategy/technical_alignment.py
@@ -1,0 +1,22 @@
+"""Technical analysis alignment with sentiment."""
+from __future__ import annotations
+
+from typing import Dict
+import pandas as pd
+
+try:
+    import ta
+except Exception:  # pragma: no cover - ta optional
+    ta = None
+
+
+def check_alignment(df: pd.DataFrame, sentiment_label: str) -> bool:
+    """Return True if technicals align with sentiment."""
+    if ta is None or df.empty:
+        return False
+    rsi = ta.momentum.rsi(df["close"], window=14).iloc[-1]
+    macd = ta.trend.macd(df["close"]).iloc[-1]
+    if sentiment_label == "positive" and rsi < 30 and macd > 0:
+        return True
+    return False
+

--- a/utils/ensemble_model_router.py
+++ b/utils/ensemble_model_router.py
@@ -1,0 +1,12 @@
+"""Route text to the correct sentiment model."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def route(text: str, lang: str = "en") -> Any:
+    """Return placeholder model based on language or content."""
+    if lang != "en":
+        return "multilingual-model"
+    return "finbert"
+

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,6 +1,7 @@
 # utils/logger.py
 
 import logging
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 def setup_logging(level: str = "INFO", log_file_path: str = "logs/trading_bot.log"):
@@ -10,13 +11,16 @@ def setup_logging(level: str = "INFO", log_file_path: str = "logs/trading_bot.lo
     Path("logs").mkdir(exist_ok=True)
 
     log_format = "[%(asctime)s] [%(levelname)s] %(message)s"
+    file_handler = RotatingFileHandler(
+        log_file_path,
+        mode="a",
+        maxBytes=1024 * 1024,
+        backupCount=5,
+    )
     logging.basicConfig(
         level=level.upper(),
         format=log_format,
-        handlers=[
-            logging.StreamHandler(),
-            logging.FileHandler(log_file_path, mode='a')
-        ]
+        handlers=[logging.StreamHandler(), file_handler],
     )
 
     logging.info("Logging initialized.")


### PR DESCRIPTION
## Summary
- add placeholder configuration in `settings.yaml`
- enhance logging with rotation
- extend requirements with additional ML packages
- scaffold advanced sentiment modules (NER, decay, volatility, etc.)
- scaffold new strategy tools (technical alignment, backtester, profit guardrails, etc.)
- provide utility for routing sentiment models
- expose a unified `get_sentiment_score` API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da1bbad388330af363836a943c11f