### PR TITLE
Implement MarketSnapshot logging & safety updates

### DIFF
--- a/dashboard/views/agent_status.py
+++ b/dashboard/views/agent_status.py
@@ -1,16 +1,41 @@
+import json
+from pathlib import Path
 import streamlit as st
-from typing import Dict
+
+LOG_PATH = "logs/agent_history.json"
 
 
-def show_agent_status(info: Dict, auto_mode: bool = True):
-    """Display the latest agent decision."""
-    status = "ON" if auto_mode else "OFF"
-    st.header(f"🤖 Agent Status ({status})")
+def _load_last_entry():
+    path = Path(LOG_PATH)
+    if not path.is_file():
+        return None
+    try:
+        line = path.read_text().strip().splitlines()[-1]
+        return json.loads(line)
+    except Exception:
+        return None
+
+
+def show_agent_status():
+    st.header("🤖 Agent Status")
+    auto = st.session_state.get("autonomous", True)
+    st.checkbox("Autonomous Mode", value=auto, key="autonomous")
+
+    info = _load_last_entry()
     if not info:
         st.info("No agent activity yet.")
         return
-    decision = info.get("decision", {})
-    st.write(f"Time: {info.get('timestamp')}")
-    st.write(f"Action: {decision.get('action')}")
-    st.write(f"Confidence: {decision.get('confidence')}")
-    st.write(f"Rationale: {decision.get('rationale') or decision.get('reason')}")
+
+    st.subheader(f"Last decision for {info['ticker']}")
+    st.write(f"Price: {info['price']}")
+    st.write(f"Decision: {info['decision'].get('action')}")
+    st.write(f"Confidence: {info['decision'].get('confidence')}")
+    st.write(f"Rationale: {info['decision'].get('rationale')}")
+    st.write(info['decision'].get('explanation'))
+
+    if st.session_state.get("pending_trade"):
+        col1, col2 = st.columns(2)
+        if col1.button("Approve Trade"):
+            st.session_state["pending_trade"] = False
+        if col2.button("Reject Trade"):
+            st.session_state["pending_trade"] = False

--- a/lysara_investments/agent/decision_engine.py
+++ b/lysara_investments/agent/decision_engine.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import Dict, Any
 import logging
 
-from .perception import MarketSnapshot
+from .market_snapshot import MarketSnapshot
+from .personality import explain_decision
 
 
 def analyze_sentiment(snapshot: MarketSnapshot) -> float:
@@ -39,6 +40,13 @@ def make_trade_decision(snapshot: MarketSnapshot, config: Dict) -> Dict[str, Any
         "confidence": round(min(confidence, 1.0), 2),
         "rationale": f"Sentiment score {sentiment_score:.2f}",
     }
+
+    decision["explanation"] = explain_decision(
+        snapshot.ticker,
+        decision["action"],
+        decision["rationale"],
+        decision["confidence"],
+    )
 
     if decision["confidence"] < threshold:
         logging.info("Decision confidence below threshold")

--- a/lysara_investments/agent/loop.py
+++ b/lysara_investments/agent/loop.py
@@ -9,8 +9,9 @@ from typing import Dict
 from .perception import gather_market_snapshot
 from .decision_engine import make_trade_decision
 from .executor import TradeExecutor
-from .memory import AgentMemory
+from .memory import AgentMemory, log_trade_decision
 from .safety import SafetyMonitor
+from .market_snapshot import MarketSnapshot
 from db.db_manager import DatabaseManager
 
 
@@ -25,11 +26,11 @@ class AgentLoop:
         self.symbol = config.get("crypto_settings", {}).get("trade_symbols", ["BTC-USD"])[0]
 
     async def step(self):
-        snapshot = await gather_market_snapshot(self.config)
+        snapshot = await gather_market_snapshot(self.config, self.symbol)
         decision = make_trade_decision(snapshot, self.config)
-        self.memory.log_decision(decision, {"prices": snapshot.prices})
+        log_trade_decision(snapshot, decision)
         if self.safety.check():
-            await self.executor.execute(decision, self.symbol)
+            await self.executor.execute(snapshot, decision)
         else:
             logging.warning("Agent disabled by safety monitor")
 

--- a/lysara_investments/agent/market_snapshot.py
+++ b/lysara_investments/agent/market_snapshot.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Any
+
+
+@dataclass
+class MarketSnapshot:
+    ticker: str
+    price: float
+    sentiment: Dict[str, Any]
+    technicals: Dict[str, Any]
+    volatility: float
+    timestamp: datetime

--- a/lysara_investments/agent/memory.py
+++ b/lysara_investments/agent/memory.py
@@ -3,10 +3,28 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Dict, Any
 from datetime import datetime
 import logging
+
+LOG_PATH = "logs/agent_history.json"
+
+def log_trade_decision(snapshot, decision: dict):
+    log_entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "ticker": snapshot.ticker,
+        "price": snapshot.price,
+        "sentiment": snapshot.sentiment,
+        "technicals": snapshot.technicals,
+        "volatility": snapshot.volatility,
+        "decision": decision,
+    }
+    if not os.path.exists("logs"):
+        os.makedirs("logs")
+    with open(LOG_PATH, "a") as f:
+        f.write(json.dumps(log_entry) + "\n")
 
 from db.db_manager import DatabaseManager
 

--- a/lysara_investments/agent/perception.py
+++ b/lysara_investments/agent/perception.py
@@ -2,35 +2,24 @@ from __future__ import annotations
 
 """Market perception module for Lysara agent."""
 
-from dataclasses import dataclass
 from typing import Dict, Any
 import logging
+from datetime import datetime
 
 from api.crypto_api import CryptoAPI
 from data.sentiment import (
     fetch_cryptopanic_sentiment,
     fetch_reddit_sentiment,
 )
-from utils.helpers import format_timestamp
+from .market_snapshot import MarketSnapshot
 
 
-@dataclass
-class MarketSnapshot:
-    """Unified view of current market data."""
-
-    prices: Dict[str, float]
-    sentiment: Dict[str, Any]
-    timestamp: str
-
-
-async def gather_market_snapshot(config: Dict) -> MarketSnapshot:
-    """Collect prices and sentiment into a single snapshot."""
+async def gather_market_snapshot(config: Dict, symbol: str) -> MarketSnapshot:
+    """Collect prices and sentiment for a single symbol."""
 
     api_keys = config.get("api_keys", {})
-    symbols = config.get("crypto_settings", {}).get("trade_symbols", [])
-
-    prices: Dict[str, float] = {}
     sentiment: Dict[str, Any] = {}
+    price: float = 0.0
 
     # ---- Price Data -----------------------------------------------------
     if api_keys.get("coinbase"):
@@ -41,13 +30,11 @@ async def gather_market_snapshot(config: Dict) -> MarketSnapshot:
             simulation_mode=True,
             config=config,
         )
-        for sym in symbols:
-            try:
-                data = await api.fetch_market_price(sym)
-                prices[sym] = float(data.get("price", 0))
-            except Exception as e:  # pragma: no cover - network errors
-                logging.error(f"Price fetch failed for {sym}: {e}")
-                prices[sym] = 0.0
+        try:
+            data = await api.fetch_market_price(symbol)
+            price = float(data.get("price", 0))
+        except Exception as e:  # pragma: no cover - network errors
+            logging.error(f"Price fetch failed for {symbol}: {e}")
     else:
         logging.debug("Perception: coinbase key missing, skipping price fetch")
 
@@ -55,7 +42,7 @@ async def gather_market_snapshot(config: Dict) -> MarketSnapshot:
     cp_key = api_keys.get("cryptopanic")
     if cp_key:
         try:
-            sentiment["cryptopanic"] = await fetch_cryptopanic_sentiment(cp_key, symbols)
+            sentiment["cryptopanic"] = await fetch_cryptopanic_sentiment(cp_key, [symbol])
         except Exception as e:  # pragma: no cover - network errors
             logging.error(f"CryptoPanic fetch failed: {e}")
     subreddits = config.get("reddit_subreddits", ["Cryptocurrency"])
@@ -68,5 +55,12 @@ async def gather_market_snapshot(config: Dict) -> MarketSnapshot:
     if reddit_scores:
         sentiment["reddit"] = reddit_scores
 
-    return MarketSnapshot(prices=prices, sentiment=sentiment, timestamp=format_timestamp())
+    return MarketSnapshot(
+        ticker=symbol,
+        price=price,
+        sentiment=sentiment,
+        technicals={},
+        volatility=0.0,
+        timestamp=datetime.utcnow(),
+    )
 

--- a/lysara_investments/agent/personality.py
+++ b/lysara_investments/agent/personality.py
@@ -1,0 +1,5 @@
+"""Agent personality helpers."""
+
+
+def explain_decision(ticker, decision, rationale, confidence):
+    return f"I recommend a {decision.upper()} on {ticker}. Confidence: {confidence:.2f}. Rationale: {rationale}"

--- a/lysara_investments/agent/safety.py
+++ b/lysara_investments/agent/safety.py
@@ -8,6 +8,14 @@ from typing import Dict
 from db.db_manager import DatabaseManager
 
 
+def is_safe_to_trade(balance, recent_drawdown, confidence, max_drawdown=0.15, min_confidence=0.7):
+    if recent_drawdown >= max_drawdown:
+        return False
+    if confidence < min_confidence:
+        return False
+    return True
+
+
 class SafetyMonitor:
     """Monitor trading activity and disable when limits hit."""
 
@@ -54,4 +62,5 @@ class SafetyMonitor:
             return False
         self.check_drawdown()
         return not self.disabled
+
 

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+from datetime import datetime
+
+from lysara_investments.agent.market_snapshot import MarketSnapshot
+from lysara_investments.agent.decision_engine import make_trade_decision
+from lysara_investments.agent.memory import log_trade_decision
+from lysara_investments.agent.personality import explain_decision
+
+
+class AgentRunTest(unittest.TestCase):
+    def test_snapshot_decision_logging(self):
+        snapshot = MarketSnapshot(
+            ticker="TEST",
+            price=100.0,
+            sentiment={"reddit": {"test": {"score": 0.5}}},
+            technicals={},
+            volatility=0.1,
+            timestamp=datetime.utcnow(),
+        )
+        decision = make_trade_decision(snapshot, {"confidence_threshold": 0.1})
+        explanation = explain_decision(
+            snapshot.ticker,
+            decision["action"],
+            decision["rationale"],
+            decision["confidence"],
+        )
+        self.assertEqual(decision["explanation"], explanation)
+        log_trade_decision(snapshot, decision)
+        self.assertTrue(os.path.exists("logs/agent_history.json"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MarketSnapshot` dataclass and rewrite perception layer
- log agent decisions to `logs/agent_history.json`
- add safety helper `is_safe_to_trade`
- implement simple personality explanation
- update agent loop, executor and decision engine to use new classes
- expand dashboard agent status view
- add regression test for agent run

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684da8a4a9ec83309930cb0bf4879dd1