### PR TITLE
Fix API interfaces and sentiment aggregation

### DIFF
--- a/alpaca_client.py
+++ b/alpaca_client.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import Dict, Any
 
 import requests
+from urllib.parse import urljoin
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -25,7 +26,7 @@ def _headers() -> Dict[str, str]:
 
 def _request(method: str, path: str, *, live: bool = False, **kwargs) -> Dict[str, Any]:
     base_url = LIVE_URL if live else PAPER_URL
-    url = f"{base_url.rstrip('/')}{path}"
+    url = urljoin(base_url.rstrip('/') + '/', path.lstrip('/'))
     for attempt in range(1, 4):
         try:
             resp = requests.request(method, url, headers=_headers(), timeout=10, **kwargs)

--- a/api/crypto_api.py
+++ b/api/crypto_api.py
@@ -24,3 +24,7 @@ class CryptoAPI(CoinbaseClient):
             config=config,
             trade_cooldown=trade_cooldown,
         )
+
+    async def fetch_holdings(self) -> dict:
+        """Alias for ``get_holdings`` for backward compatibility."""
+        return await self.get_holdings()

--- a/services/background_tasks.py
+++ b/services/background_tasks.py
@@ -67,5 +67,3 @@ class BackgroundTasks:
 
     def stop(self):
         self._running = False
-
-        self._running = False

--- a/signals/sentiment_manager.py
+++ b/signals/sentiment_manager.py
@@ -10,6 +10,23 @@ def get_sentiment_score(symbol: str) -> float:
         return 0.0
     try:
         data = json.loads(SENTIMENT_PATH.read_text())
-        return data.get("cryptopanic", {}).get(symbol, {}).get("score", 0.0)
+        scores = []
+
+        cp_score = data.get("cryptopanic", {}).get(symbol, {}).get("score")
+        if cp_score is not None:
+            scores.append(float(cp_score))
+
+        reddit_data = data.get("reddit", {})
+        if isinstance(reddit_data, dict):
+            for entry in reddit_data.values():
+                val = entry.get("score")
+                if val is not None:
+                    scores.append(float(val))
+
+        news_score = data.get("newsapi", {}).get("score")
+        if news_score is not None:
+            scores.append(float(news_score))
+
+        return sum(scores) / len(scores) if scores else 0.0
     except Exception:
         return 0.0

--- a/tests/test_alpaca_client.py
+++ b/tests/test_alpaca_client.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+from unittest import mock
+from alpaca_client import _request
+
+class AlpacaClientURLTest(unittest.TestCase):
+    def test_request_url_join(self):
+        os.environ['ALPACA_BASE_URL'] = 'https://paper-api.alpaca.markets/v2'
+
+        captured = {}
+        def fake_request(method, url, headers=None, timeout=10, **kwargs):
+            captured['url'] = url
+            class Resp:
+                text = ''
+                def raise_for_status(self):
+                    pass
+                def json(self):
+                    return {}
+            return Resp()
+
+        with mock.patch('requests.request', side_effect=fake_request):
+            _request('GET', '/v2/positions')
+
+        self.assertEqual(captured['url'], 'https://paper-api.alpaca.markets/v2/positions')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_crypto_api.py
+++ b/tests/test_crypto_api.py
@@ -1,0 +1,13 @@
+import unittest
+import asyncio
+from api.crypto_api import CryptoAPI
+
+class CryptoAPITest(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_holdings_alias(self):
+        api = CryptoAPI(api_key="dummy", simulation_mode=True)
+        api._mock_holdings = {"BTC": 1.0}
+        holdings = await api.fetch_holdings()
+        self.assertEqual(holdings, {"BTC": 1.0})
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sentiment_manager.py
+++ b/tests/test_sentiment_manager.py
@@ -1,0 +1,24 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from signals import sentiment_manager
+
+class SentimentManagerTest(unittest.TestCase):
+    def test_aggregated_score(self):
+        data = {
+            "cryptopanic": {"BTC-USD": {"score": 0.2}},
+            "reddit": {"crypto": {"score": 0.4}},
+            "newsapi": {"score": -0.1},
+        }
+        with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
+            json.dump(data, tmp)
+            tmp.flush()
+            sentiment_manager.SENTIMENT_PATH = Path(tmp.name)
+            score = sentiment_manager.get_sentiment_score("BTC-USD")
+        expected = (0.2 + 0.4 - 0.1) / 3
+        self.assertAlmostEqual(score, expected, places=6)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose `fetch_holdings` in `CryptoAPI`
- ensure Alpaca client joins URLs correctly
- average sentiment from all cached sources
- clean up duplicated line in background tasks
- add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684daf41c5208330b58f8734164d6d29