### PR TITLE
Integrate onchain agent launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,16 @@ __pycache__/
 
 # Virtual Envs
 .env
+.env.local
+.env.*
 .venv/
 venv/
 
 # Logs
 logs/
 *.log
+*.pem
+secrets/
 
 # System
 .DS_Store

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,17 @@
+import argparse
+import logging
+
+from services.onchain_agent_launcher import launch_agent
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the onchain agent")
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run in test mode without blockchain interaction",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    launch_agent(test=args.test)

--- a/dashboard/controls/trading_controls.py
+++ b/dashboard/controls/trading_controls.py
@@ -3,8 +3,11 @@
 import streamlit as st
 import json
 from pathlib import Path
+import subprocess
+import sys
 
 CONTROL_FILE = Path("dashboard") / "controls" / "control_flags.json"
+
 
 def _write_flags(flags: dict):
     """Persist control flags (start/stop commands) for bots to pick up."""
@@ -12,6 +15,7 @@ def _write_flags(flags: dict):
     data = CONTROL_FILE.exists() and json.loads(CONTROL_FILE.read_text()) or {}
     data.update(flags)
     CONTROL_FILE.write_text(json.dumps(data, indent=2))
+
 
 def show_trading_controls(sim_portfolio=None):
     st.sidebar.header("🔧 Trading Controls")
@@ -35,3 +39,7 @@ def show_trading_controls(sim_portfolio=None):
     if sim_portfolio and st.sidebar.button("Reset Simulation"):
         sim_portfolio.reset()
         st.sidebar.success("🧹 Simulation reset")
+
+    if st.sidebar.button("Launch Onchain Agent"):
+        subprocess.Popen([sys.executable, "chatbot.py"])  # noqa: S603
+        st.sidebar.info("🤖 Onchain agent launched")

--- a/launcher.py
+++ b/launcher.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 def stream_output(proc: subprocess.Popen, label: str, buffer: List[str]):
     """Forward process output to the terminal while storing it."""
     try:
-        for line in iter(proc.stdout.readline, ''):
+        for line in iter(proc.stdout.readline, ""):
             if not line:
                 break
             buffer.append(line)
@@ -32,7 +32,9 @@ def start_process(cmd: List[str], label: str):
             text=True,
             bufsize=1,
         )
-        thread = threading.Thread(target=stream_output, args=(proc, label, buffer), daemon=True)
+        thread = threading.Thread(
+            target=stream_output, args=(proc, label, buffer), daemon=True
+        )
         thread.start()
         logging.info(f"{label} launched successfully.")
         return proc, buffer
@@ -45,10 +47,33 @@ def main():
     if sys.prefix == sys.base_prefix:
         logging.warning("⚠️ Warning: Not running inside the virtual environment!")
     parser = argparse.ArgumentParser(description="Launch trading bot and dashboard")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Default options for launching the trading bot
     mode_group = parser.add_mutually_exclusive_group()
-    mode_group.add_argument("--simulate", action="store_true", help="Run bot in simulation mode")
-    mode_group.add_argument("--live", action="store_true", help="Run bot in live trading mode")
+    mode_group.add_argument(
+        "--simulate", action="store_true", help="Run bot in simulation mode"
+    )
+    mode_group.add_argument(
+        "--live", action="store_true", help="Run bot in live trading mode"
+    )
+
+    # Onchain agent command
+    agent_parser = subparsers.add_parser("launch-agent", help="Run the onchain agent")
+    agent_parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Simulate agent actions without blockchain interaction",
+    )
+
     args = parser.parse_args()
+
+    if args.command == "launch-agent":
+        agent_cmd = [sys.executable, "chatbot.py"]
+        if args.test:
+            agent_cmd.append("--test")
+        subprocess.run(agent_cmd, check=False)
+        return
 
     bot_cmd = [sys.executable, "main.py"]
     if args.simulate:
@@ -57,7 +82,9 @@ def main():
         bot_cmd.append("--live")
 
     bot_proc, bot_buffer = start_process(bot_cmd, "Bot")
-    dash_proc, dash_buffer = start_process(["streamlit", "run", "dashboard/app.py"], "Dashboard")
+    dash_proc, dash_buffer = start_process(
+        ["streamlit", "run", "dashboard/app.py"], "Dashboard"
+    )
 
     if dash_proc:
         logging.info("Dashboard running at http://localhost:8501")
@@ -66,13 +93,21 @@ def main():
         while True:
             time.sleep(1)
             if bot_proc and bot_proc.poll() is not None:
-                err = ''.join(bot_buffer[-10:]).strip()
-                msg = f"[!] Bot crashed with error: {err}" if err else f"[!] Bot exited with code {bot_proc.returncode}"
+                err = "".join(bot_buffer[-10:]).strip()
+                msg = (
+                    f"[!] Bot crashed with error: {err}"
+                    if err
+                    else f"[!] Bot exited with code {bot_proc.returncode}"
+                )
                 logging.error(msg)
                 break
             if dash_proc and dash_proc.poll() is not None:
-                err = ''.join(dash_buffer[-10:]).strip()
-                msg = f"[!] Dashboard crashed with error: {err}" if err else f"[!] Dashboard exited with code {dash_proc.returncode}"
+                err = "".join(dash_buffer[-10:]).strip()
+                msg = (
+                    f"[!] Dashboard crashed with error: {err}"
+                    if err
+                    else f"[!] Dashboard exited with code {dash_proc.returncode}"
+                )
                 logging.error(msg)
                 break
     except KeyboardInterrupt:

--- a/onchain_agent/initialize_agent.py
+++ b/onchain_agent/initialize_agent.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Tuple
+
+from web3 import Web3
+from eth_account import Account
+from coinbase_agentkit.agentkit import AgentKit, AgentKitConfig
+
+
+def initialize_agent(
+    private_key_pem: str,
+    cdp_api_key: str,
+    chain_id: int,
+    rpc_url: str,
+    test: bool = False,
+) -> Tuple[AgentKit, Web3, str]:
+    """Initialize the onchain agent and return useful objects.
+
+    Parameters
+    ----------
+    private_key_pem : str
+        PEM-formatted private key text.
+    cdp_api_key : str
+        Coinbase Developer Platform API key.
+    chain_id : int
+        Target chain id.
+    rpc_url : str
+        RPC endpoint for the chain.
+    test : bool, optional
+        If True, skip RPC connectivity checks.
+    """
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    if not test and not w3.is_connected():
+        raise ValueError("Unable to connect to RPC endpoint")
+
+    try:
+        account = Account.from_key(private_key_pem)
+    except Exception as exc:
+        raise ValueError(f"Invalid private key: {exc}") from exc
+
+    config = AgentKitConfig(cdp_api_key_id=cdp_api_key)
+    agent = AgentKit(config)
+
+    logging.info(f"Agent wallet address: {account.address}")
+    logging.info(f"Connected to RPC {rpc_url}")
+    return agent, w3, account.address

--- a/services/onchain_agent_launcher.py
+++ b/services/onchain_agent_launcher.py
@@ -1,0 +1,55 @@
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from onchain_agent.initialize_agent import initialize_agent
+
+
+def _load_private_key(path: Path) -> Optional[str]:
+    try:
+        key = path.read_text().strip()
+        logging.info(f"Loaded PEM key from {path}")
+        return key
+    except FileNotFoundError:
+        logging.error(f"Private key file not found at {path}")
+    except Exception as exc:
+        logging.error(f"Failed to load PEM key: {exc}")
+    return None
+
+
+def launch_agent(test: bool = False):
+    """Load configuration and start the onchain agent."""
+    pem_path = Path("secrets/coinbase_private_key.pem")
+    private_key = _load_private_key(pem_path)
+    if not private_key:
+        return
+
+    cdp_api_key = os.getenv("CDP_API_KEY")
+    chain_id = os.getenv("CHAIN_ID")
+    rpc_url = os.getenv("RPC_URL")
+
+    missing = [
+        name
+        for name, val in [
+            ("CDP_API_KEY", cdp_api_key),
+            ("CHAIN_ID", chain_id),
+            ("RPC_URL", rpc_url),
+        ]
+        if not val
+    ]
+    if missing:
+        logging.error(f"Missing required env vars: {', '.join(missing)}")
+        return
+
+    try:
+        chain_id_int = int(chain_id)
+    except ValueError:
+        logging.error("CHAIN_ID must be an integer")
+        return
+
+    try:
+        initialize_agent(private_key, cdp_api_key, chain_id_int, rpc_url, test=test)
+    except Exception as exc:
+        logging.error(f"Agent initialization failed: {exc}")
+        return


### PR DESCRIPTION
## Summary
- scaffold `onchain_agent` package with agent initialization helper
- add `services/onchain_agent_launcher.py` for loading keys and environment variables
- create `chatbot.py` entrypoint for running the onchain agent
- extend `launcher.py` with `launch-agent` command
- add dashboard button to launch the agent
- ignore environment and key files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd76764f08330bf8cd196c199d617