### PR TITLE
Integrate Binance API with strategies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -53,3 +53,18 @@ in the dashboard and launcher are hidden.
 The new `OpportunityScanner` leverages CoinGecko trending data and sentiment
 signals to surface promising assets. Temporary symbols will be added for one
 hour when discovered.
+
+## Testing Notes
+
+When running the bot in simulation mode after these Binance upgrades,
+verify the following:
+
+1. **Market Data** – prices from Binance WebSocket should stream without
+   errors and update your logs.
+2. **Account Info** – `fetch_account_info` and `fetch_holdings` must return
+   reasonable balances from Binance or mock values in simulation.
+3. **Order Execution** – simulated orders should log correctly and update the
+   `SimulatedPortfolio`; when live trading is enabled, ensure orders are
+   accepted by Binance.
+4. **Strategy Inputs** – confirm strategies reference sentiment scores from
+   CryptoPanic, NewsAPI and Reddit when generating trade decisions.

--- a/lysara_investments/agent/executor.py
+++ b/lysara_investments/agent/executor.py
@@ -54,6 +54,11 @@ class TradeExecutor:
         qty = self.risk.get_position_size(price)
         side = "buy" if action == "BUY" else "sell"
         logging.info(f"Executing {side} {qty} {snapshot.ticker} @ {price}")
-        result = await self.api.place_order(snapshot.ticker, qty, side, confidence=decision.get("confidence"))
+        result = await self.api.place_order(
+            symbol=snapshot.ticker,
+            side=side,
+            qty=qty,
+            confidence=decision.get("confidence"),
+        )
         return result
 

--- a/strategies/crypto/mean_reversion.py
+++ b/strategies/crypto/mean_reversion.py
@@ -43,11 +43,11 @@ class MeanReversionStrategy(BaseStrategy):
             return
 
         order = await self.api.place_order(
-            product_id=symbol,
+            symbol=symbol,
             side=side,
-            size=qty,
+            qty=qty,
             price=price,
-            order_type="market",
+            order_type="MARKET",
             confidence=0.0,
         )
 

--- a/strategies/crypto/micro_scalping.py
+++ b/strategies/crypto/micro_scalping.py
@@ -41,10 +41,10 @@ class MicroScalpingStrategy(BaseStrategy):
             logging.warning("MicroScalping: invalid position size")
             return
         await self.api.place_order(
-            product_id=symbol,
+            symbol=symbol,
             side=side,
-            size=qty,
-            order_type="market",
+            qty=qty,
+            order_type="MARKET",
             price=price,
             confidence=0.0,
         )

--- a/strategies/crypto/momentum.py
+++ b/strategies/crypto/momentum.py
@@ -128,10 +128,10 @@ class MomentumStrategy(BaseStrategy):
             return
 
         await self.api.place_order(
-            product_id=symbol,
+            symbol=symbol,
             side=action,
-            size=qty,
-            order_type="market",
+            qty=qty,
+            order_type="MARKET",
             price=price,
             confidence=confidence,
         )

--- a/strategies/crypto/pairs_trading.py
+++ b/strategies/crypto/pairs_trading.py
@@ -54,12 +54,12 @@ class PairsTradingStrategy(BaseStrategy):
 
         if direction == "long":
             # Buy 1, Sell 2
-            await self.api.place_order(product_id=self.pair[0], side="buy", size=qty_1, price=price_1, confidence=0.0)
-            await self.api.place_order(product_id=self.pair[1], side="sell", size=qty_2, price=price_2, confidence=0.0)
+            await self.api.place_order(symbol=self.pair[0], side="buy", qty=qty_1, price=price_1, order_type="MARKET", confidence=0.0)
+            await self.api.place_order(symbol=self.pair[1], side="sell", qty=qty_2, price=price_2, order_type="MARKET", confidence=0.0)
         else:
             # Sell 1, Buy 2
-            await self.api.place_order(product_id=self.pair[0], side="sell", size=qty_1, price=price_1, confidence=0.0)
-            await self.api.place_order(product_id=self.pair[1], side="buy", size=qty_2, price=price_2, confidence=0.0)
+            await self.api.place_order(symbol=self.pair[0], side="sell", qty=qty_1, price=price_1, order_type="MARKET", confidence=0.0)
+            await self.api.place_order(symbol=self.pair[1], side="buy", qty=qty_2, price=price_2, order_type="MARKET", confidence=0.0)
 
         self.db.log_trade(
             symbol=f"{self.pair[0]}+{self.pair[1]}",


### PR DESCRIPTION
## Summary
- wire new CryptoAPI (Binance) into crypto strategies
- fix TradeExecutor order invocation
- document simulation testing steps for Binance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813ac95968833081c9be172e5e681e