### PR TITLE
Switch Binance endpoints to Binance.US

### DIFF
--- a/api/binance_client.py
+++ b/api/binance_client.py
@@ -1,5 +1,5 @@
 # api/binance_client.py
-"""Async Binance client for core trading operations."""
+"""Async Binance client for core trading operations using Binance.US."""
 
 from __future__ import annotations
 
@@ -24,7 +24,8 @@ class BinanceClient(BaseAPI):
         self,
         api_key: str,
         api_secret: str,
-        base_url: str = "https://api.binance.com",
+        # Use Binance.US for all REST API calls
+        base_url: str = "https://api.binance.us",
         simulation_mode: bool = True,
         portfolio=None,
         config: Optional[Dict] = None,

--- a/data/market_data_crypto.py
+++ b/data/market_data_crypto.py
@@ -6,6 +6,8 @@ import json
 import logging
 from datetime import datetime
 
+# This module is configured to use Binance.US endpoints
+
 # Default subscription message if no symbols provided.
 SUBSCRIBE_MESSAGE = {
     "method": "SUBSCRIBE",
@@ -22,7 +24,8 @@ async def start_crypto_market_feed(symbols: list[str], on_message=handle_market_
     """Launch a Binance WebSocket connection for real-time ticker data."""
     # Coinbase WebSocket does not provide unique sentiment streams, so we use
     # Binance for market data and trading. Coinbase support has been removed.
-    uri = "wss://stream.binance.com:9443/stream"
+    # Connect to Binance.US WebSocket endpoint
+    uri = "wss://stream.binance.us:9443/stream"
     stream = "/".join([f"{s.lower().replace('-', '')}@ticker" for s in symbols])
     subscribe_msg = {
         "method": "SUBSCRIBE",


### PR DESCRIPTION
## Summary
- point BinanceClient to Binance.US REST endpoint
- connect crypto WebSocket feed to Binance.US

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881417c28a8833097a24ea951fbad21