### PR TITLE
Disable CryptoPanic and CoinGecko network calls

### DIFF
--- a/data/market_data_coingecko.py
+++ b/data/market_data_coingecko.py
@@ -37,23 +37,7 @@ async def start_coingecko_polling(symbols: list[str], interval: int = 60, on_dat
     Stock tickers are ignored. Prices already provided by Binance take
     precedence over CoinGecko data.
     """
-    coin_ids = []
-    for s in symbols:
-        if "-" not in s:
-            logging.debug(f"Skipping non-crypto symbol {s} for CoinGecko polling")
-            continue
-        coin_ids.append(s.split("-")[0].lower())
-    async with aiohttp.ClientSession() as session:
-        while True:
-            for cid in coin_ids:
-                canonical = f"{cid.upper()}-USD"
-                cached = get_price(canonical)
-                if cached and cached.get("source") in {"binance", "alpaca"}:
-                    continue  # prefer exchange price
-                data = await fetch_coingecko_price(session, cid)
-                if on_data:
-                    await on_data(data)
-                else:
-                    logging.info(f"[COINGECKO] {cid} @ {data['price']}")
-            await asyncio.sleep(interval)
+    logging.info("CoinGecko price polling disabled")
+    while True:
+        await asyncio.sleep(interval)
 

--- a/data/sentiment.py
+++ b/data/sentiment.py
@@ -19,42 +19,42 @@ def analyze_sentiment(text: str) -> float:
 
 # === CryptoPanic ===
 
-async def fetch_cryptopanic_sentiment(api_key: str, symbols: list[str]) -> dict:
-    """
-    Pulls latest sentiment data for crypto from CryptoPanic API.
-    """
-    url = "https://cryptopanic.com/api/v1/posts/"
-    headers = {"Accept": "application/json"}
-    result = {}
+# The CryptoPanic API integration has been removed.
+# The original function has been commented out to disable requests.
 
-    async with aiohttp.ClientSession() as session:
-        for symbol in symbols:
-            params = {
-                "auth_token": api_key,
-                "currencies": symbol.split("-")[0].lower(),
-                "filter": "rising",
-                "public": "true"
-            }
-            try:
-                async with session.get(url, params=params, headers=headers) as response:
-                    data = await response.json()
-                    posts = data.get("results", [])
-                    scores = [
-                        analyze_sentiment(
-                            (p.get("title") or "") + " " + (p.get("body") or "")
-                        )
-                        for p in posts
-                    ]
-                    avg_score = round(sum(scores) / len(scores), 3) if scores else 0.0
-                    result[symbol] = {
-                        "score": avg_score,
-                        "count": len(scores),
-                        "timestamp": datetime.utcnow().isoformat()
-                    }
-            except Exception as e:
-                logging.error(f"CryptoPanic error for {symbol}: {e}")
-                result[symbol] = {"score": 0.0, "count": 0}
-    return result
+# async def fetch_cryptopanic_sentiment(api_key: str, symbols: list[str]) -> dict:
+#     """Pulls latest sentiment data for crypto from CryptoPanic API."""
+#     url = "https://cryptopanic.com/api/v1/posts/"
+#     headers = {"Accept": "application/json"}
+#     result = {}
+#     async with aiohttp.ClientSession() as session:
+#         for symbol in symbols:
+#             params = {
+#                 "auth_token": api_key,
+#                 "currencies": symbol.split("-")[0].lower(),
+#                 "filter": "rising",
+#                 "public": "true"
+#             }
+#             try:
+#                 async with session.get(url, params=params, headers=headers) as response:
+#                     data = await response.json()
+#                     posts = data.get("results", [])
+#                     scores = [
+#                         analyze_sentiment(
+#                             (p.get("title") or "") + " " + (p.get("body") or "")
+#                         )
+#                         for p in posts
+#                     ]
+#                     avg_score = round(sum(scores) / len(scores), 3) if scores else 0.0
+#                     result[symbol] = {
+#                         "score": avg_score,
+#                         "count": len(scores),
+#                         "timestamp": datetime.utcnow().isoformat()
+#                     }
+#             except Exception as e:
+#                 logging.error(f"CryptoPanic error for {symbol}: {e}")
+#                 result[symbol] = {"score": 0.0, "count": 0}
+#     return result
 
 # === NewsAPI ===
 

--- a/lysara_investments/agent/perception.py
+++ b/lysara_investments/agent/perception.py
@@ -8,7 +8,6 @@ from datetime import datetime
 
 from api.crypto_api import CryptoAPI
 from data.sentiment import (
-    fetch_cryptopanic_sentiment,
     fetch_reddit_sentiment,
 )
 from .market_snapshot import MarketSnapshot
@@ -38,12 +37,6 @@ async def gather_market_snapshot(config: Dict, symbol: str) -> MarketSnapshot:
         logging.debug("Perception: binance key missing, skipping price fetch")
 
     # ---- Sentiment Data -------------------------------------------------
-    cp_key = api_keys.get("cryptopanic")
-    if cp_key:
-        try:
-            sentiment["cryptopanic"] = await fetch_cryptopanic_sentiment(cp_key, [symbol])
-        except Exception as e:  # pragma: no cover - network errors
-            logging.error(f"CryptoPanic fetch failed: {e}")
     subreddits = config.get("reddit_subreddits", ["Cryptocurrency"])
     reddit_scores: Dict[str, Any] = {}
     for sub in subreddits:

--- a/services/background_tasks.py
+++ b/services/background_tasks.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 from data.sentiment import (
-    fetch_cryptopanic_sentiment,
     fetch_newsapi_sentiment,
     fetch_reddit_sentiment,
 )
@@ -15,7 +14,6 @@ class BackgroundTasks:
     def __init__(self, config: dict):
         self.config = config
         self.crypto_symbols = config.get("TRADE_SYMBOLS", ["BTC-USD", "ETH-USD"])
-        self.cp_key = config["api_keys"].get("cryptopanic")
         self.newsapi_key = config["api_keys"].get("newsapi")
         self.subreddits = config.get("reddit_subreddits", ["Cryptocurrency"])
         self.sentiment_scores: dict = {}
@@ -36,11 +34,6 @@ class BackgroundTasks:
         """
         while self._running:
             logging.info("Running sentiment fetch loop...")
-
-            if self.cp_key:
-                scores = await fetch_cryptopanic_sentiment(self.cp_key, self.crypto_symbols)
-                self.sentiment_scores["cryptopanic"] = scores
-                logging.info(f"CryptoPanic Sentiment: {scores}")
 
             if self.newsapi_key:
                 news = await fetch_newsapi_sentiment(self.newsapi_key)

--- a/signals/sentiment_manager.py
+++ b/signals/sentiment_manager.py
@@ -12,10 +12,6 @@ def get_sentiment_score(symbol: str) -> float:
         data = json.loads(SENTIMENT_PATH.read_text())
         scores = []
 
-        cp_score = data.get("cryptopanic", {}).get(symbol, {}).get("score")
-        if cp_score is not None:
-            scores.append(float(cp_score))
-
         reddit_data = data.get("reddit", {})
         if isinstance(reddit_data, dict):
             for entry in reddit_data.values():

--- a/signals/signal_fusion_engine.py
+++ b/signals/signal_fusion_engine.py
@@ -11,7 +11,6 @@ from indicators.technical_indicators import (
 
 from data.sentiment import (
     fetch_newsapi_sentiment,
-    fetch_cryptopanic_sentiment,
     fetch_reddit_sentiment,
 )
 
@@ -35,7 +34,6 @@ class SignalFusionEngine:
         self.market_weight = float(config.get("MARKET_WEIGHT", 0.2))
         self.reddit_subs = config.get("REDDIT_SUBS", ["CryptoCurrency"])
         self.news_key = config.get("NEWSAPI_KEY")
-        self.cp_key = config.get("CRYPTOPANIC_KEY")
         self.loop = asyncio.get_event_loop()
 
     async def sentiment_score(self, symbol: str) -> float:
@@ -43,8 +41,6 @@ class SignalFusionEngine:
         tasks = []
         if self.news_key:
             tasks.append(fetch_newsapi_sentiment(self.news_key, symbol))
-        if self.cp_key:
-            tasks.append(fetch_cryptopanic_sentiment(self.cp_key, [symbol]))
         for sub in self.reddit_subs:
             tasks.append(fetch_reddit_sentiment(sub))
         results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/strategies/crypto/momentum.py
+++ b/strategies/crypto/momentum.py
@@ -58,7 +58,6 @@ class MomentumStrategy(BaseStrategy):
         if not self.sentiment_source:
             return 0.0
         scores = self.sentiment_source.sentiment_scores
-        cp = scores.get("cryptopanic", {}).get(symbol, {}).get("score", 0.0)
         reddit_data = scores.get("reddit", {})
         reddit_avg = 0.0
         if reddit_data:
@@ -66,7 +65,7 @@ class MomentumStrategy(BaseStrategy):
                 reddit_avg += sub.get("score", 0.0)
             reddit_avg /= max(len(reddit_data), 1)
         news = scores.get("newsapi", {}).get("score", 0.0)
-        return (cp + reddit_avg + news) / 3
+        return (reddit_avg + news) / 2
 
     def _build_context(self, symbol: str, price: float, sentiment: float) -> dict:
         prices = self.price_history[symbol]

--- a/tests/test_sentiment_manager.py
+++ b/tests/test_sentiment_manager.py
@@ -8,7 +8,6 @@ from signals import sentiment_manager
 class SentimentManagerTest(unittest.TestCase):
     def test_aggregated_score(self):
         data = {
-            "cryptopanic": {"BTC-USD": {"score": 0.2}},
             "reddit": {"crypto": {"score": 0.4}},
             "newsapi": {"score": -0.1},
         }
@@ -17,7 +16,7 @@ class SentimentManagerTest(unittest.TestCase):
             tmp.flush()
             sentiment_manager.SENTIMENT_PATH = Path(tmp.name)
             score = sentiment_manager.get_sentiment_score("BTC-USD")
-        expected = (0.2 + 0.4 - 0.1) / 3
+        expected = (0.4 - 0.1) / 2
         self.assertAlmostEqual(score, expected, places=6)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- comment out the CryptoPanic sentiment fetcher and remove all usages
- disable CoinGecko polling so it no longer calls the API
- clean up background tasks and perception modules
- adjust momentum strategy and signal fusion engine
- update sentiment manager and its tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818c6fc02483309092e90c947d1b77